### PR TITLE
Gracefully fail when a user tries to create multiple recording sessions

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -41,12 +41,14 @@ func runRecordCmd(cmd *cobra.Command, args []string) {
 
 	commands, err := startRecording()
 	if err != nil {
-		panic(err)
+		savvy_errors.DisplayWithSupportCTA(err)
+		os.Exit(1)
 	}
 
 	gm := component.NewGenerateRunbookModel(commands, cl)
 	p := tea.NewProgram(gm)
 	if _, err := p.Run(); err != nil {
+		// TODO: fail gracefully. Provider users either a link to view the runbook or a list of their saved commands
 		fmt.Printf("could not run program: %s\n", err)
 		os.Exit(1)
 	}
@@ -55,6 +57,7 @@ func runRecordCmd(cmd *cobra.Command, args []string) {
 	m := newDisplayCommandsModel(runbook)
 	p = tea.NewProgram(m, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
+		// TODO: fail gracefully and provide users a link to view the runbook
 		fmt.Printf("could not run program: %s\n", err)
 		os.Exit(1)
 	}
@@ -65,7 +68,7 @@ func startRecording() ([]string, error) {
 	socketPath := "/tmp/savvy-socket"
 	ss, err := server.NewUnixSocketServer(socketPath)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	// TODO: kill this goroutine when the shell exits
 	go ss.ListenAndServe()

--- a/savvy_errors/style.go
+++ b/savvy_errors/style.go
@@ -11,6 +11,26 @@ var style = lipgloss.NewStyle().
 	PaddingTop(1).
 	Foreground(lipgloss.Color("9"))
 
-func Display(err error) {
+// Display prints the error and any additional messages to the terminal
+func Display(err error, msgs ...string) {
+	// be defensive
+	if err == nil {
+		return
+	}
+
+	errMsg := err.Error()
+	if errMsg == "" {
+		return
+	}
+
 	fmt.Println(style.Render(err.Error()))
+	for _, msg := range msgs {
+		fmt.Println(style.Render(msg))
+	}
+}
+
+const supportCTA = `Stuck? We're here to make things easiser for you. Just email us at support@getsavvy.so or join our friendly Discord community (https://getsavvy.so/discord) for a chat.`
+
+func DisplayWithSupportCTA(err error) {
+	Display(err, supportCTA)
 }


### PR DESCRIPTION
- errors: Add function that appends a CTA to reach out to support to any error
- cmd/record: fail gracefully when user tries to create a concurrent recording session
