### PR TITLE
rm panics 

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -78,7 +78,8 @@ func startRecording() ([]string, error) {
 	ctx := context.Background()
 	c, err := sh.Spawn(ctx)
 	if err != nil {
-		panic(err)
+		err := fmt.Errorf("failed to start recording: %w", err)
+		return nil, err
 	}
 
 	// Start the command with a pty.

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -109,10 +109,7 @@ func startRecording() ([]string, error) {
 		return nil, fmt.Errorf("failed to set stdin to raw mode: %w", err)
 	}
 	defer func() {
-		err = term.Restore(int(os.Stdin.Fd()), oldState)
-		if err != nil {
-			panic(err)
-		}
+		term.Restore(int(os.Stdin.Fd()), oldState)
 	}() // Best effort.
 
 	// Copy stdin to the pty and the pty to stdout.

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -106,7 +106,7 @@ func startRecording() ([]string, error) {
 	// Set stdin in raw mode.
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to set stdin to raw mode: %w", err)
 	}
 	defer func() {
 		err = term.Restore(int(os.Stdin.Fd()), oldState)

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"text/template"
 )
 
@@ -119,7 +120,7 @@ unset _SAVVY_USER_ZDOTDIR
 func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
 	// Referenced: https://github.com/sbstp/kubie/blob/master/src/shell/zsh.rs
 	tmp := os.TempDir()
-	zshrcPath := tmp + string(os.PathSeparator) + ".zshrc"
+	zshrcPath := filepath.Join(tmp, ".zshrc")
 	zshrc, err := os.Create(zshrcPath)
 	if err != nil {
 		return nil, err

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -129,7 +129,10 @@ func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
 
 	t := template.Must(template.New("zshrc").Parse(script))
 
-	t.Execute(zshrc, z)
+	if err := t.Execute(zshrc, z); err != nil {
+		return nil, err
+	}
+
 	cmd := exec.CommandContext(ctx, z.shellCmd)
 	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=1")
 	return cmd, nil


### PR DESCRIPTION
- shell: use filepath.Join instead of os.FilePathSepartor
- shell/zsh: handle err from instantiating zshrc template
- cmd/record: handle err spawing sub-shell to record a guide
- cmd/record: handle error when putting ptty in raw mode
- cmd/record: do not panic if pty can't be restored
- cmd/record: handle errs displaying or generating a runbook after recording it
