### PR TITLE
server: kill ListenAndServe when the server is closed

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -75,7 +75,6 @@ func startRecording() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: kill this goroutine when the shell exits
 	go ss.ListenAndServe()
 	defer ss.Close()
 	// Create arbitrary command.

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -124,7 +124,6 @@ func startRecording() ([]string, error) {
 	if err := c.Wait(); err != nil {
 		// TODO: inspect the error and determine if we exited due to ctrl-c or exit or something else.
 	}
-	// close the shell
 	if err := term.Restore(int(os.Stdin.Fd()), oldState); err != nil {
 		// intentionally display the error and continue
 		display.Error(err)

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"text/template"
+	"time"
 )
 
 type Shell interface {
@@ -133,8 +134,9 @@ func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, z.shellCmd)
+	cmd := exec.Command(z.shellCmd)
 	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=1")
+	cmd.WaitDelay = 2 * time.Second
 	return cmd, nil
 }
 


### PR DESCRIPTION
- server: exit ListenAndServe after Listener has closed
- cmd/record: rm stray comment
- shell: create Command with exec.Command instead of exec.CommandContext
