### PR TITLE
login: return early if the token is valid

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -69,6 +69,12 @@ func (lm loginModel) View() string {
 }
 
 func runLogin(cmd *cobra.Command, args []string) {
+	if err := verifyLogin(); err == nil {
+		display.Info("You are already logged in!")
+		display.Info("Run `savvy login --force` to get a new token")
+		return
+	}
+
 	var browserOpenError = fmt.Errorf("couldn't open your default browser. Please visit %s in your browser", savvyLoginURL)
 	display.Info(fmt.Sprintf("Opening your default browser to %s", savvyLoginURL))
 	browserCmd := browser.Open(savvyLoginURL)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -69,7 +69,13 @@ func (lm loginModel) View() string {
 }
 
 func runLogin(cmd *cobra.Command, args []string) {
-	if err := verifyLogin(); err == nil {
+	force, err := cmd.Flags().GetBool(forceLoginFlag)
+	if err != nil {
+		display.ErrorWithSupportCTA(fmt.Errorf("error parsing flags: %w", err))
+		os.Exit(1)
+	}
+
+	if err := verifyLogin(); err == nil && !force {
 		display.Info("You are already logged in!")
 		display.Info("Run `savvy login --force` to get a new token")
 		return
@@ -124,6 +130,10 @@ func verifyLogin() error {
 	return err
 }
 
+const forceLoginFlag = "force"
+const forceLoginFlagShort = "f"
+
 func init() {
+	loginCmd.Flags().BoolP(forceLoginFlag, forceLoginFlagShort, false, "Force new login flow")
 	rootCmd.AddCommand(loginCmd)
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,13 +19,6 @@ var loginCmd = &cobra.Command{
 	Short: "Login to savvy",
 	Long:  `Login allows users to use Google SSO to login to savvy.`,
 	Run:   runLogin,
-	PostRun: func(cmd *cobra.Command, args []string) {
-		if err := verifyLogin(); err != nil {
-			display.ErrorWithSupportCTA(fmt.Errorf("login failed: %w", err))
-			os.Exit(1)
-		}
-		display.Success("Login successful!")
-	},
 }
 
 var savvyLoginURL string = config.APIHost() + "/login"
@@ -102,6 +95,14 @@ func runLogin(cmd *cobra.Command, args []string) {
 		tok := model.textInput.Value()
 		// Remove quotes and braces and spaces from token
 		tok = strings.Trim(tok, "\"{} ")
+
+		defer func() {
+			if err := verifyLogin(); err != nil {
+				display.ErrorWithSupportCTA(fmt.Errorf("login failed: %w", err))
+				os.Exit(1)
+			}
+			display.Success("Login successful!")
+		}()
 
 		cfg := config.Config{Token: tok}
 		if err := cfg.Save(); err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -76,7 +76,7 @@ func (lm loginModel) View() string {
 }
 
 func runLogin(cmd *cobra.Command, args []string) {
-	var browserOpenError = fmt.Errorf("Couldn't open your default browser. Please visit %s in your browser", savvyLoginURL)
+	var browserOpenError = fmt.Errorf("couldn't open your default browser. Please visit %s in your browser", savvyLoginURL)
 	display.Info(fmt.Sprintf("Opening your default browser to %s", savvyLoginURL))
 	browserCmd := browser.Open(savvyLoginURL)
 	if browserCmd == nil {
@@ -90,7 +90,7 @@ func runLogin(cmd *cobra.Command, args []string) {
 
 	m, err := p.Run()
 	if err != nil {
-		display.ErrorWithSupportCTA(fmt.Errorf("login error: %v\n", err))
+		display.ErrorWithSupportCTA(fmt.Errorf("login error: %w\n", err))
 		os.Exit(1)
 	} else {
 		model := m.(loginModel)
@@ -105,7 +105,7 @@ func runLogin(cmd *cobra.Command, args []string) {
 
 		cfg := config.Config{Token: tok}
 		if err := cfg.Save(); err != nil {
-			err = fmt.Errorf("Error saving config: %w", err)
+			err = fmt.Errorf("error saving config: %w", err)
 			display.ErrorWithSupportCTA(err)
 			os.Exit(1)
 		}

--- a/display/info.go
+++ b/display/info.go
@@ -9,11 +9,7 @@ import (
 var infoStyle = lipgloss.NewStyle().
 	Bold(false).
 	PaddingTop(1).
-	PaddingBottom(1).
-	Foreground(lipgloss.AdaptiveColor{
-		Light: "21",
-		Dark:  "33",
-	})
+	PaddingBottom(1)
 
 func Info(text string) {
 	fmt.Println(infoStyle.Render(text))


### PR DESCRIPTION
Fixes #1

- login: fix error formatting
- login: inline token check in runLogin
- display/info: rm color for info text
- login: return early if token is valid
- login: add --force/-f flag to force new login flow
