### PR TITLE
cmd/record: ux improvements

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -66,6 +66,9 @@ func runRecordCmd(cmd *cobra.Command, args []string) {
 		display.ErrorWithSupportCTA(fmt.Errorf("could not display runbook: %w", err))
 		os.Exit(1)
 	}
+	if runbook.URL != "" {
+		display.Success("View and edit your runbook online at: " + runbook.URL)
+	}
 }
 
 func startRecording() ([]string, error) {

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -97,26 +97,6 @@ if [[ -f "${_SAVVY_USER_ZDOTDIR:-$HOME}/.zlogin" && "$SAVVY_LOGIN_SHELL" == "1" 
 fi
 
 unset _SAVVY_USER_ZDOTDIR
-
-# autoload -Uz add-zsh-hook
-#
-# This function fixes the prompt via a precmd hook.
-# function __savvy_cmd_pre_cmd__() {
-#  local status=$?
-#  echo "exit_status: ${status}</command>" > $SAVVY_STATUS_FILE
-# }
-
-# function __savvy_cmd_pre_exec__() {
-#   # $2 is the command with all the aliases expanded
-#   local cmd=$3
-#   echo "${cmd}" | nc -U $SAVVY_INPUT_FILE
-# }
-# add-zsh-hook preexec __savvy_cmd_pre_exec__
-
-# When promptinit is activated, a precmd hook which updates PS1 is installed.
-# In order to inject the kubie PS1 when promptinit is activated, we must
-# also add our own precmd hook which modifies PS1 after promptinit themes.
-# add-zsh-hook precmd __savvy_cmd_pre_cmd__
 `
 
 func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -63,9 +63,17 @@ if [[ -f "$HOME/.zsh_history" ]] ; then
 fi
 
 SAVVY_LOGIN_SHELL=0
-if [[ "$OSTYPE" == "darwin"* ]] ; then
-    SAVVY_LOGIN_SHELL=1
-fi
+
+case "$OSTYPE" in
+  solaris*) SAVVY_LOGIN_SHELL=1;;
+  darwin*)  SAVVY_LOGIN_SHELL=1;;
+  linux*)   SAVVY_LOGIN_SHELL=1;;
+  bsd*)     SAVVY_LOGIN_SHELL=1;;
+  msys*)    echo "windows os is not supported" ;;
+  cygwin*)  echo "windows os is not supported" ;;
+  *)        echo "unknown: $OSTYPE" ;;
+esac
+
 if [[ -f "/etc/zprofile" && "$SAVVY_LOGIN_SHELL" == "1" ]] ; then
     source "/etc/zprofile"
 elif [[ -f "/etc/zsh/zprofile" && "$SAVVY_LOGIN_SHELL" == "1" ]] ; then

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -105,6 +105,9 @@ if [[ -f "${_SAVVY_USER_ZDOTDIR:-$HOME}/.zlogin" && "$SAVVY_LOGIN_SHELL" == "1" 
 fi
 
 unset _SAVVY_USER_ZDOTDIR
+
+echo
+echo "Type 'exit' or press 'ctrl+d' when you done recording."
 `
 
 func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
@@ -132,5 +135,5 @@ func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
 type todo struct{}
 
 func (t *todo) Spawn(ctx context.Context) (*exec.Cmd, error) {
-	return nil, errors.New("Not implemented")
+	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
- cmd/record: share runbook url with users at the end
- shell/zsh: rm unused hooks
- shell/zsh: support linux and macOS.
- shell/zsh: inform users how to stop recording
