### PR TITLE
cmd/whoami: handle nil response from default roundtripper 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,10 @@ func (a *AuthorizedRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 
 	// Use the embedded Transport to perform the actual request
 	res, err := http.DefaultTransport.RoundTrip(clonedReq)
+	if err != nil {
+		err = fmt.Errorf("%w: %v", ErrInvalidClient, err)
+		return nil, err
+	}
 
 	// If we get a 401 Unauthorized, then the token is expired
 	// and we need to refresh it

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/spf13/cobra"
 )
@@ -10,17 +12,17 @@ var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Shows information about the current user",
 	Long:  "Shows information about the current user",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, _ []string) {
 		cl, err := client.New()
 		if err != nil {
-			return err
+			fmt.Println(err)
+			return
 		}
 		whoami, err := cl.WhoAmI(cmd.Context())
 		if err != nil {
-			return err
+			cmd.PrintErrln(err)
 		}
 		cmd.Println(whoami)
-		return nil
 	},
 }
 


### PR DESCRIPTION
- client: handle nil response from defaultRoundTrip
- cmd/whoami: explicitly print error
