### PR TITLE
cmd/record: cancel ctx for spawned sub-shell when pty closes

### DIFF
--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -126,7 +126,7 @@ func (z *zsh) Spawn(ctx context.Context) (*exec.Cmd, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command(z.shellCmd)
+	cmd := exec.CommandContext(ctx, z.shellCmd)
 	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=1")
 	cmd.WaitDelay = 2 * time.Second
 	return cmd, nil


### PR DESCRIPTION
When the user presses exit or ctrl-d, the pty will be closed and
io.Copy(os.Stdout, ptmx) will unblock and we will call cancelCtx

This should get rid of the scenario where users press ctrl-d or exit and
the terminal just hangs blocked waiting for c.Wait() to unblock.

We force c.Wait() to unblock by cancelling the context.
