### PR TITLE
add support for bash 

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,4 +26,6 @@ var initCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.AddCommand(setup.ZshCmd)
+	initCmd.AddCommand(setup.BashCmd)
+	initCmd.AddCommand(setup.DashCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"github.com/getsavvyinc/savvy-cli/cmd/setup"
+	"github.com/getsavvyinc/savvy-cli/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ var initCmd = &cobra.Command{
 	Short: "Output shell setup",
 	Long:  `Output shell setup`,
 
-	ValidArgs: setup.SupportedShells,
+	ValidArgs: shell.SupportedShells(),
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -1,0 +1,397 @@
+# Grateful for rcaloras and others' work on https://github.com/rcaloras/bash-preexec (MIT License)
+#
+# bash-preexec.sh -- Bash support for ZSH-like 'preexec' and 'precmd' functions.
+# https://github.com/rcaloras/bash-preexec
+#
+#
+# 'preexec' functions are executed before each interactive command is
+# executed, with the interactive command as its argument. The 'precmd'
+# function is executed before each prompt is displayed.
+#
+# Author: Ryan Caloras (ryan@bashhub.com)
+# Forked from Original Author: Glyph Lefkowitz
+#
+# V0.5.0
+#
+
+# General Usage:
+#
+#  1. Source this file at the end of your bash profile so as not to interfere
+#     with anything else that's using PROMPT_COMMAND.
+#
+#  2. Add any precmd or preexec functions by appending them to their arrays:
+#       e.g.
+#       precmd_functions+=(my_precmd_function)
+#       precmd_functions+=(some_other_precmd_function)
+#
+#       preexec_functions+=(my_preexec_function)
+#
+#  3. Consider changing anything using the DEBUG trap or PROMPT_COMMAND
+#     to use preexec and precmd instead. Preexisting usages will be
+#     preserved, but doing so manually may be less surprising.
+#
+#  Note: This module requires two Bash features which you must not otherwise be
+#  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. If you override
+#  either of these after bash-preexec has been installed it will most likely break.
+
+# Tell shellcheck what kind of file this is.
+# shellcheck shell=bash
+
+# Make sure this is bash that's running and return otherwise.
+# Use POSIX syntax for this line:
+if [ -z "${BASH_VERSION-}" ]; then
+    return 1;
+fi
+
+# We only support Bash 3.1+.
+# Note: BASH_VERSINFO is first available in Bash-2.0.
+if [[ -z "${BASH_VERSINFO-}" ]] || (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1) )); then
+    return 1
+fi
+
+# Avoid duplicate inclusion
+if [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" ]]; then
+    return 0
+fi
+bash_preexec_imported="defined"
+
+# WARNING: This variable is no longer used and should not be relied upon.
+# Use ${bash_preexec_imported} instead.
+# shellcheck disable=SC2034
+__bp_imported="${bash_preexec_imported}"
+
+# Should be available to each precmd and preexec
+# functions, should they want it. $? and $_ are available as $? and $_, but
+# $PIPESTATUS is available only in a copy, $BP_PIPESTATUS.
+# TODO: Figure out how to restore PIPESTATUS before each precmd or preexec
+# function.
+__bp_last_ret_value="$?"
+BP_PIPESTATUS=("${PIPESTATUS[@]}")
+__bp_last_argument_prev_command="$_"
+
+__bp_inside_precmd=0
+__bp_inside_preexec=0
+
+# Initial PROMPT_COMMAND string that is removed from PROMPT_COMMAND post __bp_install
+__bp_install_string=$'__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install'
+
+# Fails if any of the given variables are readonly
+# Reference https://stackoverflow.com/a/4441178
+__bp_require_not_readonly() {
+  local var
+  for var; do
+    if ! ( unset "$var" 2> /dev/null ); then
+      echo "bash-preexec requires write access to ${var}" >&2
+      return 1
+    fi
+  done
+}
+
+# Remove ignorespace and or replace ignoreboth from HISTCONTROL
+# so we can accurately invoke preexec with a command from our
+# history even if it starts with a space.
+__bp_adjust_histcontrol() {
+    local histcontrol
+    histcontrol="${HISTCONTROL:-}"
+    histcontrol="${histcontrol//ignorespace}"
+    # Replace ignoreboth with ignoredups
+    if [[ "$histcontrol" == *"ignoreboth"* ]]; then
+        histcontrol="ignoredups:${histcontrol//ignoreboth}"
+    fi;
+    export HISTCONTROL="$histcontrol"
+}
+
+# This variable describes whether we are currently in "interactive mode";
+# i.e. whether this shell has just executed a prompt and is waiting for user
+# input.  It documents whether the current command invoked by the trace hook is
+# run interactively by the user; it's set immediately after the prompt hook,
+# and unset as soon as the trace hook is run.
+__bp_preexec_interactive_mode=""
+
+# These arrays are used to add functions to be run before, or after, prompts.
+declare -a precmd_functions
+declare -a preexec_functions
+
+# Trims leading and trailing whitespace from $2 and writes it to the variable
+# name passed as $1
+__bp_trim_whitespace() {
+    local var=${1:?} text=${2:-}
+    text="${text#"${text%%[![:space:]]*}"}"   # remove leading whitespace characters
+    text="${text%"${text##*[![:space:]]}"}"   # remove trailing whitespace characters
+    printf -v "$var" '%s' "$text"
+}
+
+
+# Trims whitespace and removes any leading or trailing semicolons from $2 and
+# writes the resulting string to the variable name passed as $1. Used for
+# manipulating substrings in PROMPT_COMMAND
+__bp_sanitize_string() {
+    local var=${1:?} text=${2:-} sanitized
+    __bp_trim_whitespace sanitized "$text"
+    sanitized=${sanitized%;}
+    sanitized=${sanitized#;}
+    __bp_trim_whitespace sanitized "$sanitized"
+    printf -v "$var" '%s' "$sanitized"
+}
+
+# This function is installed as part of the PROMPT_COMMAND;
+# It sets a variable to indicate that the prompt was just displayed,
+# to allow the DEBUG trap to know that the next command is likely interactive.
+__bp_interactive_mode() {
+    __bp_preexec_interactive_mode="on";
+}
+
+
+# This function is installed as part of the PROMPT_COMMAND.
+# It will invoke any functions defined in the precmd_functions array.
+__bp_precmd_invoke_cmd() {
+    # Save the returned value from our last command, and from each process in
+    # its pipeline. Note: this MUST be the first thing done in this function.
+    # BP_PIPESTATUS may be unused, ignore
+    # shellcheck disable=SC2034
+
+    __bp_last_ret_value="$?" BP_PIPESTATUS=("${PIPESTATUS[@]}")
+
+    # Don't invoke precmds if we are inside an execution of an "original
+    # prompt command" by another precmd execution loop. This avoids infinite
+    # recursion.
+    if (( __bp_inside_precmd > 0 )); then
+      return
+    fi
+    local __bp_inside_precmd=1
+
+    # Invoke every function defined in our function array.
+    local precmd_function
+    for precmd_function in "${precmd_functions[@]}"; do
+
+        # Only execute this function if it actually exists.
+        # Test existence of functions with: declare -[Ff]
+        if type -t "$precmd_function" 1>/dev/null; then
+            __bp_set_ret_value "$__bp_last_ret_value" "$__bp_last_argument_prev_command"
+            # Quote our function invocation to prevent issues with IFS
+            "$precmd_function"
+        fi
+    done
+
+    __bp_set_ret_value "$__bp_last_ret_value"
+}
+
+# Sets a return value in $?. We may want to get access to the $? variable in our
+# precmd functions. This is available for instance in zsh. We can simulate it in bash
+# by setting the value here.
+__bp_set_ret_value() {
+    return ${1:+"$1"}
+}
+
+__bp_in_prompt_command() {
+
+    local prompt_command_array IFS=$'\n;'
+    read -rd '' -a prompt_command_array <<< "${PROMPT_COMMAND[*]:-}"
+
+    local trimmed_arg
+    __bp_trim_whitespace trimmed_arg "${1:-}"
+
+    local command trimmed_command
+    for command in "${prompt_command_array[@]:-}"; do
+        __bp_trim_whitespace trimmed_command "$command"
+        if [[ "$trimmed_command" == "$trimmed_arg" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# This function is installed as the DEBUG trap.  It is invoked before each
+# interactive prompt display.  Its purpose is to inspect the current
+# environment to attempt to detect if the current command is being invoked
+# interactively, and invoke 'preexec' if so.
+__bp_preexec_invoke_exec() {
+
+    # Save the contents of $_ so that it can be restored later on.
+    # https://stackoverflow.com/questions/40944532/bash-preserve-in-a-debug-trap#40944702
+    __bp_last_argument_prev_command="${1:-}"
+    # Don't invoke preexecs if we are inside of another preexec.
+    if (( __bp_inside_preexec > 0 )); then
+      return
+    fi
+    local __bp_inside_preexec=1
+
+    # Checks if the file descriptor is not standard out (i.e. '1')
+    # __bp_delay_install checks if we're in test. Needed for bats to run.
+    # Prevents preexec from being invoked for functions in PS1
+    if [[ ! -t 1 && -z "${__bp_delay_install:-}" ]]; then
+        return
+    fi
+
+    if [[ -n "${COMP_LINE:-}" ]]; then
+        # We're in the middle of a completer. This obviously can't be
+        # an interactively issued command.
+        return
+    fi
+    if [[ -z "${__bp_preexec_interactive_mode:-}" ]]; then
+        # We're doing something related to displaying the prompt.  Let the
+        # prompt set the title instead of me.
+        return
+    else
+        # If we're in a subshell, then the prompt won't be re-displayed to put
+        # us back into interactive mode, so let's not set the variable back.
+        # In other words, if you have a subshell like
+        #   (sleep 1; sleep 2)
+        # You want to see the 'sleep 2' as a set_command_title as well.
+        if [[ 0 -eq "${BASH_SUBSHELL:-}" ]]; then
+            __bp_preexec_interactive_mode=""
+        fi
+    fi
+
+    if  __bp_in_prompt_command "${BASH_COMMAND:-}"; then
+        # If we're executing something inside our prompt_command then we don't
+        # want to call preexec. Bash prior to 3.1 can't detect this at all :/
+        __bp_preexec_interactive_mode=""
+        return
+    fi
+
+    local this_command
+    this_command=$(
+        export LC_ALL=C
+        HISTTIMEFORMAT='' builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
+    )
+
+    # Sanity check to make sure we have something to invoke our function with.
+    if [[ -z "$this_command" ]]; then
+        return
+    fi
+
+    # Invoke every function defined in our function array.
+    local preexec_function
+    local preexec_function_ret_value
+    local preexec_ret_value=0
+    for preexec_function in "${preexec_functions[@]:-}"; do
+
+        # Only execute each function if it actually exists.
+        # Test existence of function with: declare -[fF]
+        if type -t "$preexec_function" 1>/dev/null; then
+            __bp_set_ret_value "${__bp_last_ret_value:-}"
+            # Quote our function invocation to prevent issues with IFS
+            "$preexec_function" "$this_command"
+            preexec_function_ret_value="$?"
+            if [[ "$preexec_function_ret_value" != 0 ]]; then
+                preexec_ret_value="$preexec_function_ret_value"
+            fi
+        fi
+    done
+
+    # Restore the last argument of the last executed command, and set the return
+    # value of the DEBUG trap to be the return code of the last preexec function
+    # to return an error.
+    # If `extdebug` is enabled a non-zero return value from any preexec function
+    # will cause the user's command not to execute.
+    # Run `shopt -s extdebug` to enable
+    __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command"
+}
+
+__bp_install() {
+    # Exit if we already have this installed.
+    if [[ "${PROMPT_COMMAND[*]:-}" == *"__bp_precmd_invoke_cmd"* ]]; then
+        return 1;
+    fi
+
+    trap '__bp_preexec_invoke_exec "$_"' DEBUG
+
+    # Preserve any prior DEBUG trap as a preexec function
+    local prior_trap
+    # we can't easily do this with variable expansion. Leaving as sed command.
+    # shellcheck disable=SC2001
+    prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    unset __bp_trap_string
+    if [[ -n "$prior_trap" ]]; then
+        eval '__bp_original_debug_trap() {
+          '"$prior_trap"'
+        }'
+        preexec_functions+=(__bp_original_debug_trap)
+    fi
+
+    # Adjust our HISTCONTROL Variable if needed.
+    __bp_adjust_histcontrol
+
+    # Issue #25. Setting debug trap for subshells causes sessions to exit for
+    # backgrounded subshell commands (e.g. (pwd)& ). Believe this is a bug in Bash.
+    #
+    # Disabling this by default. It can be enabled by setting this variable.
+    if [[ -n "${__bp_enable_subshells:-}" ]]; then
+
+        # Set so debug trap will work be invoked in subshells.
+        set -o functrace > /dev/null 2>&1
+        shopt -s extdebug > /dev/null 2>&1
+    fi;
+
+    local existing_prompt_command
+    # Remove setting our trap install string and sanitize the existing prompt command string
+    existing_prompt_command="${PROMPT_COMMAND:-}"
+    # Edge case of appending to PROMPT_COMMAND
+    existing_prompt_command="${existing_prompt_command//$__bp_install_string/:}" # no-op
+    existing_prompt_command="${existing_prompt_command//$'\n':$'\n'/$'\n'}" # remove known-token only
+    existing_prompt_command="${existing_prompt_command//$'\n':;/$'\n'}" # remove known-token only
+    __bp_sanitize_string existing_prompt_command "$existing_prompt_command"
+    if [[ "${existing_prompt_command:-:}" == ":" ]]; then
+        existing_prompt_command=
+    fi
+
+    # Install our hooks in PROMPT_COMMAND to allow our trap to know when we've
+    # actually entered something.
+    PROMPT_COMMAND='__bp_precmd_invoke_cmd'
+    PROMPT_COMMAND+=${existing_prompt_command:+$'\n'$existing_prompt_command}
+    if (( BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1) )); then
+        PROMPT_COMMAND+=('__bp_interactive_mode')
+    else
+        # shellcheck disable=SC2179 # PROMPT_COMMAND is not an array in bash <= 5.0
+        PROMPT_COMMAND+=$'\n__bp_interactive_mode'
+    fi
+
+    # Add two functions to our arrays for convenience
+    # of definition.
+    precmd_functions+=(precmd)
+    preexec_functions+=(preexec)
+
+    # Invoke our two functions manually that were added to $PROMPT_COMMAND
+    __bp_precmd_invoke_cmd
+    __bp_interactive_mode
+}
+
+# Sets an installation string as part of our PROMPT_COMMAND to install
+# after our session has started. This allows bash-preexec to be included
+# at any point in our bash profile.
+__bp_install_after_session_init() {
+    # bash-preexec needs to modify these variables in order to work correctly
+    # if it can't, just stop the installation
+    __bp_require_not_readonly PROMPT_COMMAND HISTCONTROL HISTTIMEFORMAT || return
+
+    local sanitized_prompt_command
+    __bp_sanitize_string sanitized_prompt_command "${PROMPT_COMMAND:-}"
+    if [[ -n "$sanitized_prompt_command" ]]; then
+        # shellcheck disable=SC2178 # PROMPT_COMMAND is not an array in bash <= 5.0
+        PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
+    fi;
+    # shellcheck disable=SC2179 # PROMPT_COMMAND is not an array in bash <= 5.0
+    PROMPT_COMMAND+=${__bp_install_string}
+}
+
+# Run our install so long as we're not delaying it.
+if [[ -z "${__bp_delay_install:-}" ]]; then
+    __bp_install_after_session_init
+fi;
+
+savvy_cmd_pre_exec() {
+  echo "savvy-pre-exec: $1"
+  echo "total num of args: $#"
+  echo "all args: $@"
+}
+
+savvy_cmd_pre_cmd() {
+  if [[ "${SAVVY_CONTEXT}" == "1" && "$PS1" != *'recording'* ]]; then
+  PS1+="\[\e[31m\]recording\[\e[0m\] 😎 "
+  fi
+}
+
+pre_exec_functions+=(savvy_cmd_pre_exec)
+precmd_functions+=(savvy_cmd_pre_cmd)

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -53,6 +53,8 @@ fi
 # Enable experimental subshell support
 export __bp_enable_subshells="true"
 
+SAVVY_INPUT_FILE=/tmp/savvy-socket
+
 savvy_cmd_pre_exec() {
   #TODO: expand aliases
   local cmd=$1

--- a/cmd/setup/bash.go
+++ b/cmd/setup/bash.go
@@ -1,0 +1,37 @@
+package setup
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed bash-preexec.sh
+var bashSetupScript embed.FS
+
+const bashSetupScriptName = "bash-preexec.sh"
+
+// initCmd represents the init command
+var BashCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "Output shell setup for bash",
+	Long:  `Output shell setup for bash`,
+	RunE:  runCmd,
+}
+
+func runCmd(cmd *cobra.Command, args []string) error {
+	content, err := bashSetupScript.ReadFile(bashSetupScriptName)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(content))
+	return nil
+}
+
+var DashCmd = &cobra.Command{
+	Use:   "dash",
+	Short: "Output shell setup for dash",
+	Long:  `Output shell setup for dash`,
+	RunE:  runCmd,
+}

--- a/cmd/setup/zsh.go
+++ b/cmd/setup/zsh.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var SupportedShells = []string{"zsh"}
+var SupportedShells = []string{"zsh", "bash", "dash"}
 
 //go:embed savvy.zsh
 var zshSetupScript embed.FS

--- a/cmd/setup/zsh.go
+++ b/cmd/setup/zsh.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var SupportedShells = []string{"zsh", "bash", "dash"}
-
 //go:embed savvy.zsh
 var zshSetupScript embed.FS
 

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -56,6 +56,9 @@ else
         source "$HOME/.bashrc"
     fi
 fi
+
+echo
+echo "Type 'exit' or press 'ctrl+d' to stop recording."
 `
 
 var bashTemplate *template.Template

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -1,0 +1,84 @@
+package shell
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"text/template"
+	"time"
+)
+
+type bash struct {
+	shellCmd string
+	// Exported to use in template
+	SocketPath string
+}
+
+var _ Shell = (*bash)(nil)
+
+// Adapted from: https://github.com/sbstp/kubie/
+const bashrcScript = `
+SAVVY_LOGIN_SHELL=0
+case "$OSTYPE" in
+  solaris*) SAVVY_LOGIN_SHELL=1;;
+  darwin*)  SAVVY_LOGIN_SHELL=1;;
+  linux*)   SAVVY_LOGIN_SHELL=1;;
+  bsd*)     SAVVY_LOGIN_SHELL=1;;
+  msys*)    echo "windows os is not supported" ;;
+  cygwin*)  echo "windows os is not supported" ;;
+  *)        echo "unknown: $OSTYPE" ;;
+esac
+
+SAVVY_INPUT_FILE={{.SocketPath}}
+
+# Reference for loading behavior
+# https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/
+
+
+if [[ "$SAVVY_LOGIN_SHELL" == "1" ]] ; then
+    if [[ -f "/etc/profile" ]] ; then
+        source "/etc/profile"
+    fi
+
+    if [[ -f "$HOME/.bash_profile" ]] ; then
+        source "$HOME/.bash_profile"
+    elif [[ -f "$HOME/.bash_login" ]] ; then
+        source "$HOME/.bash_login"
+    elif [[ -f "$HOME/.profile" ]] ; then
+        source "$HOME/.profile"
+    fi
+else
+    if [[ -f "/etc/bash.bashrc" ]] ; then
+        source "/etc/bash.bashrc"
+    fi
+
+    if [[ -f "$HOME/.bashrc" ]] ; then
+        source "$HOME/.bashrc"
+    fi
+fi
+`
+
+var bashTemplate *template.Template
+
+func init() {
+	bashTemplate = template.Must(template.New("bash").Parse(bashrcScript))
+}
+
+func (b *bash) Spawn(ctx context.Context) (*exec.Cmd, error) {
+	// Create a temporary file to store the script
+	tmpDir := os.TempDir()
+	bashrc, err := os.CreateTemp(tmpDir, "savvy-bashrc-*.bash")
+	if err != nil {
+		return nil, err
+	}
+	defer bashrc.Close()
+
+	if err := bashTemplate.Execute(bashrc, b); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, b.shellCmd, "--rcfile", bashrc.Name())
+	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=1")
+	cmd.WaitDelay = 500 * time.Millisecond
+	return cmd, nil
+}

--- a/shell/detect.go
+++ b/shell/detect.go
@@ -24,6 +24,10 @@ const (
 	Fish Kind = "fish"
 )
 
+func SupportedShells() []string {
+	return []string{string(Bash), string(Zsh), string(Dash)}
+}
+
 func runPS(args []string) (string, error) {
 	out, err := exec.Command("ps", args...).CombinedOutput()
 	if err != nil {

--- a/shell/spawn.go
+++ b/shell/spawn.go
@@ -1,0 +1,37 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+type Shell interface {
+	Spawn(ctx context.Context) (*exec.Cmd, error)
+}
+
+func New(logTarget string) Shell {
+	shell := detectWithDefault()
+	switch shell {
+	case Zsh:
+		return &zsh{
+			shellCmd:   "zsh",
+			SocketPath: logTarget,
+		}
+	case Dash:
+		fallthrough
+	case Bash:
+		return &bash{
+			shellCmd:   "bash",
+			SocketPath: logTarget,
+		}
+	default:
+		return &todo{}
+	}
+}
+
+type todo struct{}
+
+func (t *todo) Spawn(ctx context.Context) (*exec.Cmd, error) {
+	return nil, errors.New("savvy doesn't support your current shell")
+}

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -22,6 +22,13 @@ func New(logTarget string) Shell {
 			shellCmd:   "zsh",
 			SocketPath: logTarget,
 		}
+	case Dash:
+		fallthrough
+	case Bash:
+		return &bash{
+			shellCmd:   "bash",
+			SocketPath: logTarget,
+		}
 	default:
 		return &todo{}
 	}


### PR DESCRIPTION
- shell: add ability to create a bash sub-shell
- cmd: support bash and dash
- refactor(shell): extract spawn func into its own file
- cmd,shell: move logic to return SupportedShells into pkg shell
- setup/bash: add preexec and precmd funcs even when bash-preexec already exists
- set savvy_input_file
