### PR TITLE
send: use send instead of nc or echo to communicate with the unix socket

### DIFF
--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -59,7 +59,7 @@ savvy_cmd_pre_exec() {
   #TODO: expand aliases
   local cmd=$BASH_COMMAND
   if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
-    nc -w0 -U $SAVVY_INPUT_FILE <<< "$cmd"
+    SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "$cmd"
   fi
 }
 

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -14,7 +14,7 @@ function __savvy_cmd_pre_exec__() {
   # $2 is the command with all the aliases expanded
   local cmd=$3
   if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
-     nc -w0 -U $SAVVY_INPUT_FILE <<< "$cmd"
+     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "$cmd"
   fi
 }
 add-zsh-hook preexec __savvy_cmd_pre_exec__


### PR DESCRIPTION
Using echo to write data to a unix socket as if it is a regular file
"works", but it doesn't respect the usual protocol that `netcat` uses.

However, `netcat` comes in two main flavors. GNU and BSD.

BSD netcat has the -w and -U flag, both of which are missing form GNU.

The reliability of savvy record now has a hard dependency on the version
of netcat installed on the user's machine.

`socat` is a third alternative but that is not guaranteed to be
installed by default in most cases.

This commit introduces `savvy send` to address all the issue above.

`send` is a simple go program that creates a conn to the unix socket and
uses the go standard library to write data to the socket and close the
conn.

send will support all the platforms that Go supports by default and we
no longer rely on the user having a particular binary.
