### PR TITLE
debug: inject debug logger to all commands 

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -37,7 +37,7 @@ func init() {
 
 func recordHistory(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	logger := loggerFromContext(ctx)
+	logger := loggerFromCtx(ctx)
 	cl, err := client.New()
 	if err != nil && errors.Is(err, client.ErrInvalidClient) {
 		display.Error(errors.New("You must be logged in to record a runbook. Please run `savvy login`"))

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+type cmdLogger struct{}
+
+var cmdLoggerKey cmdLogger
+
+func loggerFromCtx(ctx context.Context) *slog.Logger {
+	if logger, ok := ctx.Value(cmdLoggerKey).(*slog.Logger); ok && logger != nil {
+		return logger
+	}
+	return defaultLogger
+}
+
+func ctxWithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, cmdLoggerKey, logger)
+}
+
+var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"log/slog"
 	"os"
 
@@ -13,7 +12,7 @@ var rootCmd = &cobra.Command{
 	Use:   "savvy",
 	Short: "Create, share and discover runbooks from the command line",
 	Long:  `Create, share and discover runbooks from the command line`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 		logLevel := slog.LevelInfo
 		if debugFlag {
 			logLevel = slog.LevelDebug
@@ -23,25 +22,12 @@ var rootCmd = &cobra.Command{
 			Level:     logLevel,
 		})
 		logger := slog.New(textHandler)
-		cmd.SetContext(context.WithValue(cmd.Context(), cmdLoggerKey, logger))
+		cmd.SetContext(ctxWithLogger(cmd.Context(), logger))
 	},
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
-
-var loggerFromContext = func(ctx context.Context) *slog.Logger {
-	if logger, ok := ctx.Value(cmdLoggerKey).(*slog.Logger); ok && logger != nil {
-		return logger
-	}
-	return defaultLogger
-}
-
-var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
-
-type cmdLogger struct{}
-
-var cmdLoggerKey cmdLogger
 
 var debugFlag bool
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var rootCmd = &cobra.Command{
 			Level:     logLevel,
 		})
 		logger := slog.New(textHandler)
+		slog.SetDefault(logger)
 		cmd.SetContext(ctxWithLogger(cmd.Context(), logger))
 	},
 	// Uncomment the following line if your bare application

--- a/display/error.go
+++ b/display/error.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -33,6 +34,16 @@ func ErrorMsg(msgs ...string) {
 	for _, msg := range msgs {
 		fmt.Println(style.Render(msg))
 	}
+}
+
+func FatalErr(err error, msgs ...string) {
+	Error(err, msgs...)
+	os.Exit(1)
+}
+
+func FatalErrWithSupportCTA(err error) {
+	Error(err, supportCTA)
+	os.Exit(1)
 }
 
 const supportCTA = `Stuck? We're here to make things easiser for you. Just email us at support@getsavvy.so or join our friendly Discord community (https://getsavvy.so/discord) for a chat.`

--- a/server/unix_socket.go
+++ b/server/unix_socket.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"sync"
@@ -71,7 +72,7 @@ func (s *UnixSocketServer) ListenAndServe() {
 			if s.closed.Load() {
 				return
 			}
-			fmt.Printf("Failed to accept connection: %s\n", err)
+			slog.Debug("Failed to accept connection:", "error", err.Error())
 			continue
 		}
 


### PR DESCRIPTION
- **cmd/root: setup and inject a slog instance accessible to all sub commands**
- **history: add debug logs**
- **cmd/logger: isolate logger code into its own file**
- **cmd/root: set a default logger**
- **server: log accept conn error as debug log**
- **history: wait for pty to process all commands before we cancel the context**
