### PR TITLE
history: selected commands are sorted chronologically by time.

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -123,7 +123,7 @@ func allowUserToSelectCommands(history []string) []string {
 		huh.NewGroup(
 			huh.NewMultiSelect[selectableCommand]().
 				Title("Savvy History").
-				Description("Press x to include/exclude commands in your Runbook").
+				Description("Press x to include/exclude commands in your Runbook. Selected Commands will NOT be executed.").
 				Value(&selectedOptions).
 				Height(33).
 				Options(options...),


### PR DESCRIPTION
i:e the oldest commands ( smallest unix timestamp ) will show up first.

This is the reverse order from where how the history is presented.

Usually, devs want to create a runbook from most recent commands, so we
show history in that order.

But once selected, we want to respect the chronology of time.
