### PR TITLE
savvy record: add ignoreErrors flag

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -96,8 +96,7 @@ func runRecordCmd(_ *cobra.Command, _ []string) {
 
 func startRecording() ([]string, error) {
 	// TODO: Make this unique for each invokation
-	socketPath := "/tmp/savvy-socket"
-	ss, err := server.NewUnixSocketServer(socketPath)
+	ss, err := server.NewUnixSocketServerWithDefaultPath(server.WithFilterErrors(ignoreErrors))
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func startRecording() ([]string, error) {
 		ss.Close()
 	}()
 	// Create arbitrary command.
-	sh := shell.New(socketPath)
+	sh := shell.New(ss.SocketPath())
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer func() {
 		cancelCtx()
@@ -222,6 +221,10 @@ func (dc *displayCommands) View() string {
 	return dc.l.View()
 }
 
+var ignoreErrors bool
+
 func init() {
 	rootCmd.AddCommand(recordCmd)
+	// add a boolean flag
+	recordCmd.Flags().BoolVar(&ignoreErrors, "ignore-errors", false, "Ignore commands that return an error when recording commands")
 }

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -96,7 +96,7 @@ func runRecordCmd(_ *cobra.Command, _ []string) {
 
 func startRecording() ([]string, error) {
 	// TODO: Make this unique for each invokation
-	ss, err := server.NewUnixSocketServerWithDefaultPath(server.WithFilterErrors(ignoreErrors))
+	ss, err := server.NewUnixSocketServerWithDefaultPath(server.WithIgnoreErrors(ignoreErrors))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -14,7 +14,6 @@ step_id=""
 
   # if return code is not 0, send the return code to the server
   if [[ "${SAVVY_CONTEXT}" == "1" && "${exit_code}" != "0" ]] ; then
-    echo "sending exit code to server: ${exit_code} with step_id: ${step_id}"
     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --step-id="${step_id}" --exit-code="${exit_code}"
   fi
  }

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -3,29 +3,30 @@ SAVVY_INPUT_FILE=/tmp/savvy-socket
 
 autoload -Uz add-zsh-hook
 
-step_id=0
+step_id=""
 
 # This function fixes the prompt via a precmd hook.
  function __savvy_cmd_pre_cmd__() {
-    echo "$step_id commands recorded. Press exit to stop recording."
+   local exit_code=$?
   if [[ "${SAVVY_CONTEXT}" == "1" && "$PS1" != *'recording'*  ]] ; then
       PS1+=$'%F{red}recording%f \U1f60e '
   fi
 
   # if return code is not 0, send the return code to the server
-  if [[ "${SAVVY_CONTEXT}" == "1" && "$?" != "0" ]] ; then
-    SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "{'step_id': \"${step_id}\", 'exit_status': \"$?\"}"
+  if [[ "${SAVVY_CONTEXT}" == "1" && "${exit_code}" != "0" ]] ; then
+    echo "sending exit code to server: ${exit_code} with step_id: ${step_id}"
+    SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --step-id="${step_id}" --exit-code="${exit_code}"
   fi
-
-  # increment the step id
-  ((step_id++))
  }
 
 function __savvy_cmd_pre_exec__() {
   # $2 is the command with all the aliases expanded
   local cmd=$3
+  # clear step_id
+  step_id=""
   if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
-     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "{'step_id': \"${step_id}\", 'command': \"$cmd\"}"
+    step_id=$(SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send $cmd)
+    echo "step_id: ${step_id}"
   fi
 }
 add-zsh-hook preexec __savvy_cmd_pre_exec__

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -3,18 +3,29 @@ SAVVY_INPUT_FILE=/tmp/savvy-socket
 
 autoload -Uz add-zsh-hook
 
+step_id=0
+
 # This function fixes the prompt via a precmd hook.
  function __savvy_cmd_pre_cmd__() {
+    echo "$step_id commands recorded. Press exit to stop recording."
   if [[ "${SAVVY_CONTEXT}" == "1" && "$PS1" != *'recording'*  ]] ; then
       PS1+=$'%F{red}recording%f \U1f60e '
   fi
+
+  # if return code is not 0, send the return code to the server
+  if [[ "${SAVVY_CONTEXT}" == "1" && "$?" != "0" ]] ; then
+    SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "{'step_id': \"${step_id}\", 'exit_status': \"$?\"}"
+  fi
+
+  # increment the step id
+  ((step_id++))
  }
 
 function __savvy_cmd_pre_exec__() {
   # $2 is the command with all the aliases expanded
   local cmd=$3
   if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
-     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "$cmd"
+     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send "{'step_id': \"${step_id}\", 'command': \"$cmd\"}"
   fi
 }
 add-zsh-hook preexec __savvy_cmd_pre_exec__

--- a/idgen/gen.go
+++ b/idgen/gen.go
@@ -1,0 +1,16 @@
+package idgen
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+const CommandPrefix = "cmd-"
+
+func New(prefix string) string {
+	bytes := make([]byte, 8)
+	if _, err := rand.Read(bytes); err != nil {
+		panic(err)
+	}
+	return prefix + hex.EncodeToString(bytes)
+}

--- a/idgen/gen.go
+++ b/idgen/gen.go
@@ -6,6 +6,7 @@ import (
 )
 
 const CommandPrefix = "cmd-"
+const FilePrefix = "f-"
 
 func New(prefix string) string {
 	bytes := make([]byte, 8)

--- a/server/client.go
+++ b/server/client.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"net"
+
+	"github.com/getsavvyinc/savvy-cli/idgen"
 )
 
 type Client interface {
@@ -32,8 +34,12 @@ func (c *client) Send(msg string) error {
 		return nil
 	}
 
-	// TODO: update this to send RecordedData
-	if _, err = fmt.Fprintf(conn, "%s\n", msg); err != nil {
+	data := RecordedData{
+		Command: msg,
+		StepID:  idgen.New(idgen.FilePrefix),
+	}
+
+	if err := json.NewEncoder(conn).Encode(data); err != nil {
 		return err
 	}
 	return nil

--- a/server/client.go
+++ b/server/client.go
@@ -31,6 +31,8 @@ func (c *client) Send(msg string) error {
 	if len(msg) == 0 {
 		return nil
 	}
+
+	// TODO: update this to send RecordedData
 	if _, err = fmt.Fprintf(conn, "%s\n", msg); err != nil {
 		return err
 	}

--- a/server/unix_socket.go
+++ b/server/unix_socket.go
@@ -1,22 +1,27 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
 
 type UnixSocketServer struct {
-	socketPath string
-	listener   net.Listener
+	socketPath   string
+	logger       *slog.Logger
+	listener     net.Listener
+	filterErrors bool
 
 	mu                  sync.Mutex
-	commands            []string
+	commands            []*RecordedData
+	lookupCommand       map[string]*RecordedData
 	commandRecordedHook func(string)
 
 	closed atomic.Bool
@@ -33,6 +38,20 @@ func WithCommandRecordedHook(hook func(string)) Option {
 		s.commandRecordedHook = hook
 	}
 }
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *UnixSocketServer) {
+		s.logger = logger
+	}
+}
+
+func WithFilterErrors(filter bool) Option {
+	return func(s *UnixSocketServer) {
+		s.filterErrors = filter
+	}
+}
+
+var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
 
 func NewUnixSocketServerWithDefaultPath(opts ...Option) (*UnixSocketServer, error) {
 	return NewUnixSocketServer(defaultSocketPath, opts...)
@@ -54,6 +73,7 @@ func newUnixSocketServer(socketPath string, opts ...Option) (*UnixSocketServer, 
 	srv := &UnixSocketServer{
 		socketPath: socketPath,
 		listener:   listener,
+		logger:     defaultLogger,
 	}
 
 	for _, opt := range opts {
@@ -67,7 +87,15 @@ func (s *UnixSocketServer) Commands() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.commands
+	var commands []string
+
+	for _, cmd := range s.commands {
+		if s.filterErrors && len(cmd.ExitStatus) > 0 && cmd.ExitStatus != "0" {
+			continue
+		}
+		commands = append(commands, cmd.Command)
+	}
+	return commands
 }
 
 func (s *UnixSocketServer) Close() error {
@@ -95,6 +123,12 @@ func (s *UnixSocketServer) ListenAndServe() {
 	}
 }
 
+type RecordedData struct {
+	Command    string `json:"command"`
+	StepID     string `json:"step_id"`
+	ExitStatus string `json:"exit_status"`
+}
+
 func (s *UnixSocketServer) handleConnection(c net.Conn) {
 	defer c.Close()
 
@@ -103,10 +137,20 @@ func (s *UnixSocketServer) handleConnection(c net.Conn) {
 		fmt.Printf("Failed to read from connection: %s\n", err)
 		return
 	}
-	command := string(bs)
-	s.appendCommand(command)
-	if s.commandRecordedHook != nil {
-		s.commandRecordedHook(command)
+
+	var data RecordedData
+	if err := json.Unmarshal(bs, &data); err != nil {
+		s.logger.Debug("Failed to unmarshal data", "error", err.Error(), "component", "server", "input", string(bs))
+		return
+	}
+
+	if s.maybeAppendData(data) && s.commandRecordedHook != nil {
+		s.commandRecordedHook(data.Command)
+	}
+
+	if data.Command != "" && data.ExitStatus != "0" {
+		s.logger.Debug("command failed", "command", data.Command, "exit_status", data.ExitStatus)
+		s.updateExitStatus(data.StepID, data.ExitStatus)
 	}
 }
 
@@ -114,9 +158,30 @@ func (s *UnixSocketServer) SocketPath() string {
 	return s.socketPath
 }
 
-func (s *UnixSocketServer) appendCommand(command string) {
+func (s *UnixSocketServer) updateExitStatus(stepID, exitStatus string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.commands = append(s.commands, command)
+	if cmd, ok := s.lookupCommand[stepID]; ok {
+		cmd.ExitStatus = exitStatus
+	}
+}
+
+func (s *UnixSocketServer) maybeAppendData(data RecordedData) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cmd := strings.TrimSpace(data.Command)
+
+	if cmd == "" {
+		return false
+	}
+
+	if _, ok := s.lookupCommand[data.StepID]; ok {
+		return false
+	}
+
+	s.commands = append(s.commands, &data)
+	s.logger.Debug("command recorded", "command", data.Command)
+	return true
 }


### PR DESCRIPTION
- **setup/savvy.zsh: track return code**
- **server: record command exit status and add support for ignoring errors**
- **cmd/record: add ignoreErrors flag**
- **idgen: generate id for each cmd**
- **cmd/send: generate recordedData for each step**
- **server: initialize map and rename vars**
- **server/client: todo: fix recording files**
- **server/client: update file recording to use new msg format**
- **setup/savvy.zsh: rm debug log**
