### PR TITLE
shell/expansion: ignore annoying grep expansions

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -10,6 +10,7 @@ import (
 	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/getsavvyinc/savvy-cli/idgen"
 	"github.com/getsavvyinc/savvy-cli/server"
+	"github.com/getsavvyinc/savvy-cli/shell/expansion"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,8 @@ var sendCmd = &cobra.Command{
 			// nothing to do.
 			return
 		}
+
+		message = expansion.IgnoreGrep(message)
 
 		var quite bool
 		if stepID == "" {

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -69,7 +69,17 @@ get_user_prompt() {
 
 step_id=""
 savvy_cmd_pre_exec() {
-  local cmd=$BASH_COMMAND
+  local expanded_command=""
+  local spaced_command=$(echo $1 | sed -e 's/\$(\([^)]*\))/$( \1 )/g' -e 's/`\(.*\)`/` \1 `/g')
+  local command_parts=( $spaced_command )
+  for part in "${command_parts[@]}"; do
+      if [[ "$part" =~ ^[a-zA-Z0-9_]+$ && $(type -t "$part") == "alias" ]]; then
+        expanded_command+=$(alias "$part" | sed -e "s/^[[:space:]]*alias $part='//" -e "s/^$part='//" -e "s/'$//")" "
+      else
+          expanded_command+="$part "
+      fi
+  done
+  local cmd="${expanded_command}"
   local prompt=$(get_user_prompt)
   step_id=""
   if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then

--- a/shell/expansion/ignore.go
+++ b/shell/expansion/ignore.go
@@ -1,0 +1,14 @@
+package expansion
+
+import "regexp"
+
+var grepColorExcludeDirRegexPattern = regexp.MustCompile(`grep --color=auto --exclude-dir={[\w,.]+}`)
+
+func IgnoreGrep(message string) string {
+	// grep expansions are not useful for the user with the addition of --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} by default.
+	// This is a workaround to ignore the expansions in the command.
+	if grepColorExcludeDirRegexPattern.MatchString(message) {
+		return grepColorExcludeDirRegexPattern.ReplaceAllString(message, "grep")
+	}
+	return message
+}

--- a/shell/expansion/ignore_test.go
+++ b/shell/expansion/ignore_test.go
@@ -1,0 +1,55 @@
+package expansion_test
+
+import (
+	"testing"
+
+	"github.com/getsavvyinc/savvy-cli/shell/expansion"
+)
+
+func TestIgnoreGrep(t *testing.T) {
+	testCases := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "no grep",
+			message:  "echo hello world",
+			expected: "echo hello world",
+		},
+		{
+			name:     "grep",
+			message:  `grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} "pattern"`,
+			expected: `grep "pattern"`,
+		},
+		{
+			name:     "grep with flags",
+			message:  `grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} -i "pattern"`,
+			expected: `grep -i "pattern"`,
+		},
+		{
+			name:     "grep with multiple flags",
+			message:  `grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} -i -n "pattern"`,
+			expected: `grep -i -n "pattern"`,
+		},
+		{
+			name:     "multiple grep instances",
+			message:  `grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} -i -n "pattern1" | grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} "pattern2"`,
+			expected: `grep -i -n "pattern1" | grep "pattern2"`,
+		},
+		{
+			name:     "grep with other commands",
+			message:  `echo "hello world" | grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn} "pattern"`,
+			expected: `echo "hello world" | grep "pattern"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := expansion.IgnoreGrep(tc.message)
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **shell/expansion: ignore expansions of commands like grep**
- **bash-preexec.sh: expand bash aliases in pipes and process substitution**
