### PR TITLE
savvy run: run runbooks from your terminal 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,6 +129,14 @@ type Step struct {
 	Command     string `json:"command"`
 }
 
+func (rb *Runbook) Commands() []string {
+	var commands []string
+	for _, step := range rb.Steps {
+		commands = append(commands, step.Command)
+	}
+	return commands
+}
+
 func (c *client) GenerateRunbookV2(ctx context.Context, commands []RecordedCommand) (*GeneratedRunbook, error) {
 	cl := c.cl
 	bs, err := json.Marshal(struct{ Commands []RecordedCommand }{Commands: commands})

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 type Client interface {
 	WhoAmI(ctx context.Context) (string, error)
 	GenerateRunbookV2(ctx context.Context, commands []RecordedCommand) (*GeneratedRunbook, error)
+	// Deprecated. Use GenerateRunbookV2 instead
 	GenerateRunbook(ctx context.Context, commands []string) (*GeneratedRunbook, error)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -119,8 +119,9 @@ type GeneratedRunbook struct {
 }
 
 type Runbook struct {
-	Title string `json:"title"`
-	Steps []Step `json:"steps"`
+	RunbookID string `json:"runbook_id"`
+	Title     string `json:"title"`
+	Steps     []Step `json:"steps"`
 }
 
 type Step struct {

--- a/client/guest.go
+++ b/client/guest.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getsavvyinc/savvy-cli/config"
+)
+
+var _ Client = (*guest)(nil)
+
+func NewGuest() Client {
+	return &guest{
+		cl: &http.Client{
+			Transport: &GuestRoundTripper{savvyVersion: config.Version()},
+		},
+		apiHost: config.APIHost(),
+	}
+}
+
+type GuestRoundTripper struct {
+	savvyVersion string
+}
+
+func (g *GuestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to ensure thread safety
+	clonedReq := req.Clone(req.Context())
+	clonedReq.Header.Set("X-Savvy-Version", g.savvyVersion)
+	clonedReq.Header.Set("X-Savvy-Guest", "true")
+
+	// Use the embedded Transport to perform the actual request
+	return http.DefaultTransport.RoundTrip(clonedReq)
+}
+
+type guest struct {
+	cl      *http.Client
+	apiHost string
+}
+
+// apiURL returns the full url to the api endpoint
+// path must start with a slash. e.g. /api/v1/whoami
+// apiURL will add a slash if it's missing
+func (g *guest) apiURL(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return g.apiHost + path
+}
+
+func (g *guest) WhoAmI(ctx context.Context) (string, error) {
+	return "Savvy Guest", nil
+}
+
+var ErrCannotUseGuest = errors.New("cannot use guest client for this operation")
+
+func (g *guest) GenerateRunbookV2(ctx context.Context, commands []RecordedCommand) (*GeneratedRunbook, error) {
+	return nil, fmt.Errorf("%w: %v", ErrCannotUseGuest, "generate runbook")
+}
+
+func (g *guest) GenerateRunbook(ctx context.Context, commands []string) (*GeneratedRunbook, error) {
+	return nil, fmt.Errorf("%w: %v", ErrCannotUseGuest, "generate runbook")
+}
+
+func (g *guest) RunbookByID(ctx context.Context, id string) (*Runbook, error) {
+	cl := g.cl
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.apiURL("/api/v1/public/runbook"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	qp := req.URL.Query()
+	qp.Set("runbook_id", id)
+	req.URL.RawQuery = qp.Encode()
+
+	resp, err := cl.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var runbook Runbook
+	if err := json.NewDecoder(resp.Body).Decode(&runbook); err != nil {
+		return nil, err
+	}
+	return &runbook, nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
-	"fmt"
+	"os"
 
+	"github.com/getsavvyinc/savvy-cli/client"
+	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/spf13/cobra"
 )
 
@@ -10,13 +12,30 @@ import (
 var runCmd = &cobra.Command{
 	Use:     "run",
 	Short:   "Run takes a runbook ID and runs it",
-	Example: "savvy run $r-runbookID",
+	Example: "savvy run $rb-runbookID",
 	Long:    `Run takes a runbook ID and runs it. Run automatically steps though the runbook for you, there's no need manually copy paste individual commands.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("run called")
-	},
+	Run:     savvyRun,
 }
 
 func init() {
 	rootCmd.AddCommand(runCmd)
+}
+
+func savvyRun(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	logger := loggerFromCtx(ctx).With("command", "run")
+
+	var cl client.Client
+	cl, err := client.New()
+	if err != nil {
+		logger.Debug("error creating client", "error", err, "message", "falling back to guest client")
+		cl = client.Guest()
+	}
+
+	if len(args) == 0 {
+		display.ErrorMsg("missing: runbookID")
+		os.Exit(1)
+	}
+
+	_ = cl
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -43,11 +43,10 @@ func savvyRun(cmd *cobra.Command, args []string) {
 	}
 
 	runbookID := args[0]
-	fmt.Println("Running runbook", runbookID)
 
 	rb, err := cl.RunbookByID(ctx, runbookID)
 	if err != nil {
-		logger.Error("error getting runbook", "error", err)
+		logger.Error("failed to fetch runbook", "runbook_id", runbookID, "error", err)
 		return
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -68,8 +68,6 @@ func savvyRun(cmd *cobra.Command, args []string) {
 		)
 		return
 	}
-
-	fmt.Println("next: run the runbook", rb.Title)
 }
 
 func runRunbook(ctx context.Context, runbook *client.Runbook) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:     "run",
+	Short:   "Run takes a runbook ID and runs it",
+	Example: "savvy run $r-runbookID",
+	Long:    `Run takes a runbook ID and runs it. Run automatically steps though the runbook for you, there's no need manually copy paste individual commands.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("run called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,7 +39,17 @@ func savvyRun(cmd *cobra.Command, args []string) {
 	cl, err := client.New()
 	if err != nil {
 		logger.Debug("error creating client", "error", err, "message", "falling back to guest client")
-		cl = client.Guest()
+		cl = client.NewGuest()
 	}
-	_ = cl
+
+	runbookID := args[0]
+	fmt.Println("Running runbook", runbookID)
+
+	rb, err := cl.RunbookByID(ctx, runbookID)
+	if err != nil {
+		logger.Error("error getting runbook", "error", err)
+		return
+	}
+
+	fmt.Println("Running runbook", rb.Title)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,10 +3,21 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
 	huhSpinner "github.com/charmbracelet/huh/spinner"
+	"github.com/creack/pty"
 	"github.com/getsavvyinc/savvy-cli/client"
+	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/shell"
+	"github.com/muesli/cancelreader"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // runCmd represents the run command
@@ -51,7 +62,90 @@ func savvyRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	if err := runRunbook(ctx, rb); err != nil {
+		display.ErrorWithSupportCTA(
+			fmt.Errorf("failed to run runbook %s: %w", rb.Title, err),
+		)
+		return
+	}
+
 	fmt.Println("next: run the runbook", rb.Title)
+}
+
+func runRunbook(ctx context.Context, runbook *client.Runbook) error {
+	sh := shell.New("/tmp/savvy-socket")
+	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
+
+	c, err := sh.SpawnRunbookRunner(ctx, runbook)
+	if err != nil {
+		err := fmt.Errorf("run: failed to spawn shell %w", err)
+		return err
+	}
+
+	// Start the command with a pty.
+	ptmx, err := pty.Start(c)
+	if err != nil {
+		return err
+	}
+	// Make sure to close the pty at the end.
+	defer ptmx.Close()
+
+	// Handle pty size.
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
+				log.Printf("error resizing pty: %s", err)
+			}
+		}
+	}()
+	ch <- syscall.SIGWINCH                        // Initial resize.
+	defer func() { signal.Stop(ch); close(ch) }() // Cleanup signals when done.
+
+	// Set stdin in raw mode.
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to set stdin to raw mode: %w", err)
+	}
+
+	// Restore the terminal to its original state when we're done.
+	defer func() {
+		if err := term.Restore(int(os.Stdin.Fd()), oldState); err != nil {
+			// intentionally display the error and continue without exiting
+			display.Error(err)
+		}
+	}()
+
+	// Create a cancelable reader
+	// This is used to cancel the reader when the user types 'exit' or 'ctrl+d' to exit the subshell
+	// Without this, the io.Copy blocks until the _next_ read that conflicts with bubbletea attempting to read from os.Stdin later on.
+	cancelReader, err := cancelreader.NewReader(os.Stdin)
+	if err != nil {
+		display.Error(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		io.Copy(ptmx, cancelReader)
+	}()
+
+	// io.Copy blocks till ptmx is closed.
+	io.Copy(os.Stdout, ptmx)
+
+	// cleanup
+	//// cancel ctx and wait for the underlying shell command to finish
+	cancelCtx()
+	c.Wait()
+
+	//// cancel the cancelReader and wait for it's go routine to finish
+	cancelReader.Cancel()
+	wg.Wait()
+	return nil
 }
 
 func fetchRunbook(ctx context.Context, cl client.Client, runbookID string) (*client.Runbook, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,20 +1,30 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/getsavvyinc/savvy-cli/client"
-	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/spf13/cobra"
 )
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
-	Use:     "run",
+	Use:     "run [runbookID]",
 	Short:   "Run takes a runbook ID and runs it",
-	Example: "savvy run $rb-runbookID",
-	Long:    `Run takes a runbook ID and runs it. Run automatically steps though the runbook for you, there's no need manually copy paste individual commands.`,
-	Run:     savvyRun,
+	Example: "savvy run rb-runbookID",
+	Long: `
+  Run takes a runbook ID and runs it.
+
+  Run automatically steps though the runbook for you, there's no need manually copy paste individual commands.
+  `,
+	Run: savvyRun,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("missing: runbookID\n")
+		}
+		return nil
+	},
+	// Args: cobra.ExactArgs(1),
 }
 
 func init() {
@@ -31,11 +41,5 @@ func savvyRun(cmd *cobra.Command, args []string) {
 		logger.Debug("error creating client", "error", err, "message", "falling back to guest client")
 		cl = client.Guest()
 	}
-
-	if len(args) == 0 {
-		display.ErrorMsg("missing: runbookID")
-		os.Exit(1)
-	}
-
 	_ = cl
 }

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -40,7 +40,7 @@ function __savvy_run_pre_exec__() {
 
 # SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
 
-SAVVY_COMMANDS="(${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
+SAVVY_COMMANDS=("${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
 num_commands=${#SAVVY_COMMANDS}
 function __savvy_runbook_runner__() {
   next_step_idx=${SAVVY_NEXT_STEP:1}

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -6,29 +6,60 @@ autoload -Uz add-zsh-hook
 step_id=""
 
 # This function fixes the prompt via a precmd hook.
- function __savvy_cmd_pre_cmd__() {
+ function __savvy_record_pre_cmd__() {
    local exit_code=$?
-  if [[ "${SAVVY_CONTEXT}" == "1" && "$PS1" != *'recording'*  ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "record" && "$PS1" != *'recording'*  ]] ; then
       PS1+=$'%F{red}recording%f \U1f60e '
   fi
 
   # if return code is not 0, send the return code to the server
-  if [[ "${SAVVY_CONTEXT}" == "1" && "${exit_code}" != "0" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "record" && "${exit_code}" != "0" ]] ; then
     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --step-id="${step_id}" --exit-code="${exit_code}"
   fi
  }
 
-function __savvy_cmd_pre_exec__() {
+function __savvy_record_pre_exec__() {
   # $2 is the command with all the aliases expanded
   local cmd=$3
   local prompt=$(print -P "$PROMPT")
   # clear step_id
   step_id=""
-  if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "record" ]] ; then
     step_id=$(SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --prompt="${prompt}" $cmd)
   fi
 }
-add-zsh-hook preexec __savvy_cmd_pre_exec__
-# NOTE: If you change this function name, you must also change the corresponding check in shell/check_setup.go
+
+function __savvy_run_pre_exec__() {
+  local cmd=$3
+  if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
+    if [[ "${cmd}" -eq "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
+      export SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
+    fi
+  fi
+}
+
+# SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
+
+SAVVY_COMMANDS="(${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
+num_commands=${#SAVVY_COMMANDS}
+function __savvy_runbook_runner__() {
+  next_step_idx=${SAVVY_NEXT_STEP:1}
+  BUFFER=${SAVVY_COMMANDS[next_step_idx]}  # Initial text to be edited by the user
+  zle end-of-line  # Accept the line for editing
+}
+
+
+
+# NOTE: If you change any function names, you must also change the corresponding check in shell/check_setup.go, shell/zsh.go
+#
 # TODO: use templates to avoid the need to manually change shell checks
-add-zsh-hook precmd __savvy_cmd_pre_cmd__
+
+if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
+  zle -N zle-line-init __savvy_runbook_runner__
+  add-zle-hook-widget zle-line-init
+fi
+
+add-zsh-hook preexec __savvy_record_pre_exec__
+add-zsh-hook preexec __savvy_run_pre_exec__
+
+add-zsh-hook precmd __savvy_record_pre_cmd__

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -2,6 +2,7 @@
 SAVVY_INPUT_FILE=/tmp/savvy-socket
 
 autoload -Uz add-zsh-hook
+autoload -Uz add-zle-hook-widget
 
 step_id=""
 
@@ -32,31 +33,31 @@ function __savvy_record_pre_exec__() {
 function __savvy_run_pre_exec__() {
   local cmd=$3
   if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
-    if [[ "${cmd}" -eq "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
-      export SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
+    if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
+      SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
     fi
   fi
 }
 
-# SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
-
-SAVVY_COMMANDS=("${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
-num_commands=${#SAVVY_COMMANDS}
 function __savvy_runbook_runner__() {
-  next_step_idx=${SAVVY_NEXT_STEP:1}
-  BUFFER=${SAVVY_COMMANDS[next_step_idx]}  # Initial text to be edited by the user
-  zle end-of-line  # Accept the line for editing
+  if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
+    next_step_idx=${SAVVY_NEXT_STEP}
+    BUFFER="${SAVVY_COMMANDS[next_step_idx]}"
+    zle end-of-line  # Accept the line for editing
+  fi
 }
-
-
 
 # NOTE: If you change any function names, you must also change the corresponding check in shell/check_setup.go, shell/zsh.go
 #
 # TODO: use templates to avoid the need to manually change shell checks
 
+SAVVY_COMMANDS=()
+SAVVY_NEXT_STEP=1
 if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
   zle -N zle-line-init __savvy_runbook_runner__
-  add-zle-hook-widget zle-line-init
+  add-zle-hook-widget line-init __savvy_runbook_runner__
+  # SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
+  SAVVY_COMMANDS=("${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
 fi
 
 add-zsh-hook preexec __savvy_record_pre_exec__

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"os/user"
@@ -12,6 +13,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/tail"
 )
 
@@ -177,7 +179,11 @@ func (b *bash) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, b.shellCmd, "--rcfile", bashrc.Name())
-	cmd.Env = append(os.Environ())
+	cmd.Env = os.Environ()
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
+}
+
+func (b *bash) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
+	return nil, errors.New("savvy doesn't support your current shell")
 }

--- a/shell/spawn.go
+++ b/shell/spawn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os/exec"
 
+	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/shell/internal/detect"
 	"github.com/getsavvyinc/savvy-cli/shell/kind"
 )
@@ -13,6 +14,7 @@ type Shell interface {
 	Spawn(ctx context.Context) (*exec.Cmd, error)
 	TailHistory(ctx context.Context) ([]string, error)
 	SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error)
+	SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error)
 }
 
 func New(logTarget string) Shell {
@@ -46,5 +48,9 @@ func (t *todo) TailHistory(ctx context.Context) ([]string, error) {
 }
 
 func (t *todo) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
+	return nil, errors.New("savvy doesn't support your current shell")
+}
+
+func (t *todo) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
 	return nil, errors.New("savvy doesn't support your current shell")
 }

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -250,7 +250,7 @@ func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (
 	}
 
 	cmd := exec.CommandContext(ctx, z.shellCmd)
-	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%s", nextStep))
+	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%s", nextStep))
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
 }

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -256,8 +256,17 @@ func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (
 		nextStepIdx = 1
 	}
 
+	runbook_alias := computeRunbookAlias(runbook)
+
 	cmd := exec.CommandContext(ctx, z.shellCmd)
-	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%d", nextStepIdx))
+	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%d", nextStepIdx), fmt.Sprintf("SAVVY_RUNBOOK_ALIAS=%s", runbook_alias))
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
+}
+
+func computeRunbookAlias(runbook *client.Runbook) string {
+	lc := strings.ToLower(runbook.Title)
+	alias := strings.ReplaceAll(lc, " ", "-")
+	alias, _ = strings.CutPrefix(alias, "how-to-")
+	return alias
 }

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -249,8 +250,14 @@ func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (
 		nextStep = "1"
 	}
 
+	var nextStepIdx int
+	nextStepIdx, err = strconv.Atoi(nextStep)
+	if err != nil {
+		nextStepIdx = 1
+	}
+
 	cmd := exec.CommandContext(ctx, z.shellCmd)
-	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%s", nextStep))
+	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%d", nextStepIdx))
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
 }

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"os/user"
@@ -12,6 +13,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/tail"
 )
 
@@ -283,4 +285,8 @@ func (z *zsh) TailHistory(ctx context.Context) ([]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
+	return nil, errors.New("savvy doesn't support your current shell")
 }


### PR DESCRIPTION
- **cmd: Add skeleton for savvy run**
- **client: Allow Guest clients**
- **cmd/run: enforce 1 positional argument**
- **client: deprecate GenerateRunbook in favor of GenerateRunbookV2**
- **client: Add separate Guest client for fetching public runbooks**
- **cmd/run: fetch runbook from guest|loggedin client**
- **cmd/run: fetch runbook by runbook id**
- **cmd/run: Display spinner while we fetch the runbook**
- **client: Track runbook ID returned by Savvy's API**
- **shell: Extend shell interface to support running a runbook**
- **shell/zsh: extract common setup code into baseScript**
- **client: Fetch Commands from a client runbook**
- **shell: impl SpawnRunbookRunner**
- **cmd/run: run runbooks in a savvy sub shell**
- **cmd/run: savvy run works for zsh**
- **savvy run: Add runbook name and curr step**
