### PR TITLE
shell/zsh: use COMMA as a delimter when passing in SAVVY_RUNBOOK_COMMANDS

### DIFF
--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -81,7 +81,7 @@ if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
   zle -N zle-line-init __savvy_runbook_runner__
   add-zle-hook-widget line-init __savvy_runbook_runner__
   # SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
-  SAVVY_COMMANDS=("${(s:,:)SAVVY_RUNBOOK_COMMANDS}")
+  SAVVY_COMMANDS=("${(@s:COMMA:)SAVVY_RUNBOOK_COMMANDS}")
   SAVVY_RUN_CURR="${SAVVY_RUNBOOK_ALIAS}"
 fi
 

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -18,6 +18,8 @@ import (
 	"github.com/getsavvyinc/savvy-cli/tail"
 )
 
+const RunbookCommandDelimiter = "COMMA"
+
 type zsh struct {
 	shellCmd string
 	// Exported to use in template
@@ -259,7 +261,7 @@ func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (
 	runbook_alias := computeRunbookAlias(runbook)
 
 	cmd := exec.CommandContext(ctx, z.shellCmd)
-	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), ",")), fmt.Sprintf("SAVVY_NEXT_STEP=%d", nextStepIdx), fmt.Sprintf("SAVVY_RUNBOOK_ALIAS=%s", runbook_alias))
+	cmd.Env = append(os.Environ(), "ZDOTDIR="+tmp, "SAVVY_CONTEXT=run", fmt.Sprintf("SAVVY_RUNBOOK_COMMANDS=%s", strings.Join(runbook.Commands(), RunbookCommandDelimiter)), fmt.Sprintf("SAVVY_NEXT_STEP=%d", nextStepIdx), fmt.Sprintf("SAVVY_RUNBOOK_ALIAS=%s", runbook_alias))
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
 }


### PR DESCRIPTION
When using the literal `,` as a delimeter, we can't split on `,` to
reconstruct the sequence of commands as an array in zsh.

Commands like grep --exlcude-dir{.git,foo,etc} include false positives.

One alternative is to escape those commands, but using COMMA is simpler.

We also take this opportunity to use `@s` instead of just `s` while
splitting the string.

@s preserves the spacing and quotes around string
