### PR TITLE
savvy run: support bash 

### DIFF
--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -100,6 +100,17 @@ savvy_cmd_pre_cmd() {
   fi
 }
 
+# Define a function to set the command line before user input
+set_command() {
+    echo "Setting command"
+    READLINE_LINE="your_command_here"
+    READLINE_POINT=${#READLINE_LINE}
+}
+
+# Set up a keybinding to trigger the function
+bind 'set keyseq-timeout 0'
+bind -x '"\C-x\C-t":set_command'
+
 # Avoid duplicate inclusion
 if [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" ]]; then
     preexec_functions+=(savvy_cmd_pre_exec)

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -85,7 +85,7 @@ savvy_cmd_pre_exec() {
   local cmd="${expanded_command}"
   local prompt=$(get_user_prompt)
   step_id=""
-  if [[ "${SAVVY_CONTEXT}" == "1" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "record" ]] ; then
     step_id=$(SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --prompt="${prompt}" "$cmd")
   fi
 }
@@ -93,12 +93,12 @@ savvy_cmd_pre_exec() {
 savvy_cmd_pre_cmd() {
   local exit_code=$?
 
-  if [[ "${SAVVY_CONTEXT}" == "1" && "$PS1" != *'recording'* ]]; then
+  if [[ "${SAVVY_CONTEXT}" == "record" && "$PS1" != *'recording'* ]]; then
     PS1+=$'\[\e[31m\]recording\[\e[0m\] \U1f60e '
   fi
 
   # if return code is not 0, send the return code to the server
-  if [[ "${SAVVY_CONTEXT}" == "1" && "${exit_code}" != "0" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "record" && "${exit_code}" != "0" ]] ; then
     SAVVY_SOCKET_PATH=${SAVVY_INPUT_FILE} savvy send --step-id="${step_id}" --exit-code="${exit_code}"
   fi
 }

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -204,7 +204,11 @@ func (b *bash) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) 
 	}
 
 	cmd := exec.CommandContext(ctx, b.shellCmd, "--rcfile", bashrc.Name())
-	cmd.Env = append(os.Environ(), runbookRunMetadata(runbook)...)
+	cmd.Env = append(os.Environ(), runbookRunMetadata(runbook, b)...)
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
+}
+
+func (b *bash) DefaultStartingArrayIndex() int {
+	return 0
 }

--- a/shell/kind/kind.go
+++ b/shell/kind/kind.go
@@ -5,10 +5,11 @@ type Kind string
 
 // Define constants for ShellKind here, based on your needs, e.g., Bash, Zsh, etc.
 const (
-	Bash Kind = "bash"
-	Zsh  Kind = "zsh"
-	Dash Kind = "dash"
-	Fish Kind = "fish"
+	Bash    Kind = "bash"
+	Zsh     Kind = "zsh"
+	Dash    Kind = "dash"
+	Fish    Kind = "fish"
+	Unknown Kind = "unknown"
 )
 
 // ShellKindFromString tries to match a string to a shell Kind.
@@ -23,5 +24,5 @@ func ShellKindFromString(name string) (Kind, bool) {
 	case "fish":
 		return Fish, true
 	}
-	return "", false
+	return Unknown, false
 }

--- a/shell/spawn.go
+++ b/shell/spawn.go
@@ -15,6 +15,7 @@ type Shell interface {
 	TailHistory(ctx context.Context) ([]string, error)
 	SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error)
 	SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error)
+	DefaultStartingArrayIndex() int
 }
 
 func New(logTarget string) Shell {
@@ -53,4 +54,8 @@ func (t *todo) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 
 func (t *todo) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
 	return nil, errors.New("savvy doesn't support your current shell")
+}
+
+func (t *todo) DefaultStartingArrayIndex() int {
+	return 0
 }

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -257,6 +257,7 @@ func computeRunbookAlias(runbook *client.Runbook) string {
 	lc := strings.ToLower(runbook.Title)
 	alias := strings.ReplaceAll(lc, " ", "-")
 	alias, _ = strings.CutPrefix(alias, "how-to-")
+	alias = strings.Trim(alias, "-")
 	return alias
 }
 


### PR DESCRIPTION
- **setup/bash: trigger command completion**
- **setup/bash: Add precmd,preexec and completion binding to automatically run runbooks**
- **setup/bash: Add support for SAVVY_CONTEXT = run|record**
- **shell/zsh: Setup env vars for runner shell in one func.**
- **shell/bash: Impl SpawnRunbookRunner**
- **shell: trim leading and trailing hyphen from runbook alias**
- **shell/kind: add unknown shell kind**
- **shell: SAVVY_NEXT_STEP defaults to zero for bash and one for zsh**
