### PR TITLE
detect and handle multiple recording errors

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -64,7 +64,7 @@ func recordHistory(cmd *cobra.Command, _ []string) {
 	if err := huhSpinner.New().Title("Processing selected commands").Action(func() {
 		var err error
 
-		commands, err = expandHistory(logger, sh, selectedHistory)
+		commands, err = expandHistory(ctx, logger, sh, selectedHistory)
 		if err != nil {
 			display.FatalErrWithSupportCTA(err)
 		}
@@ -148,7 +148,7 @@ func allowUserToSelectCommands(history []string) []string {
 	return commands
 }
 
-func expandHistory(logger *slog.Logger, sh shell.Shell, rawCommands []string) ([]*server.RecordedCommand, error) {
+func expandHistory(ctx context.Context, logger *slog.Logger, sh shell.Shell, rawCommands []string) ([]*server.RecordedCommand, error) {
 	logger.Debug("expanding history", "commands", rawCommands)
 
 	commandProcessedChan := make(chan bool, 1)

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -134,7 +134,9 @@ func startRecording(ctx context.Context) ([]*server.RecordedCommand, error) {
 			return nil, errAbortRecording
 		}
 
-		ss, err = server.NewUnixSocketServerWithDefaultPath(server.WithIgnoreErrors(ignoreErrors), server.RemoveSocket())
+		server.CleanupSocket(ctx, concurrentErr.SocketPath)
+
+		ss, err = server.NewUnixSocketServerWithDefaultPath(server.WithIgnoreErrors(ignoreErrors))
 		if err != nil {
 			err := fmt.Errorf("failed to cleanup previous session: %w", err)
 			return nil, err

--- a/server/client.go
+++ b/server/client.go
@@ -14,6 +14,8 @@ import (
 type Client interface {
 	// SendFileInfo tells the server to read the file at the given path
 	SendFileInfo(filePath string) error
+	// SendShutdown tells the server to shutdown.
+	SendShutdown()
 }
 
 func NewDefaultClient(ctx context.Context) (Client, error) {
@@ -27,6 +29,20 @@ type client struct {
 }
 
 var _ Client = &client{}
+
+func (c *client) SendShutdown() {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	data := RecordedData{
+		Command: shutdownCommand,
+	}
+
+	json.NewEncoder(conn).Encode(data)
+}
 
 func (c *client) SendFileInfo(filePath string) error {
 	conn, err := net.Dial("unix", c.socketPath)

--- a/server/client.go
+++ b/server/client.go
@@ -20,7 +20,7 @@ type Client interface {
 
 func NewDefaultClient(ctx context.Context) (Client, error) {
 	return &client{
-		socketPath: defaultSocketPath,
+		socketPath: DefaultSocketPath,
 	}, nil
 }
 

--- a/server/unix_socket.go
+++ b/server/unix_socket.go
@@ -101,7 +101,6 @@ func newUnixSocketServer(socketPath string, opts ...Option) (*UnixSocketServer, 
 		return nil, fmt.Errorf("failed to create listener: %w", err)
 	}
 	srv.listener = listener
-
 	return srv, nil
 }
 
@@ -165,6 +164,13 @@ func (s *UnixSocketServer) ListenAndServe() {
 			if s.closed.Load() {
 				return
 			}
+			var netErr *net.OpError
+			if errors.As(err, &netErr) && !netErr.Temporary() {
+				slog.Debug("Fatal error", "error", err.Error())
+				s.Close()
+				return
+			}
+
 			slog.Debug("Failed to accept connection:", "error", err.Error())
 			continue
 		}


### PR DESCRIPTION
- **cmd/record: detect and fix concurrent recording sessions**
- **server: detect permanent net.OpErr and exit listen loop**
- **cmd/record: simplify code**
- **server: removing the socket doesn't end the listener; so we send a shutdown signal**
- **server: resolve concurrent errors within the server pkg**
- **cmd/history: check for multiple recordings before user selects commands**
- **history: shutdown signal should kill the shell**
