### PR TITLE
Introduce internal commands to manage execution state

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -64,6 +64,11 @@ func recordHistory(cmd *cobra.Command, _ []string) {
 		display.Info("Recording aborted")
 		return
 	}
+
+	if err != nil {
+		display.FatalErrWithSupportCTA(err)
+		return
+	}
 	defer ss.Close()
 
 	go func() {

--- a/cmd/internal/current.go
+++ b/cmd/internal/current.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/server/run"
+	"github.com/spf13/cobra"
+)
+
+// currentCmd represents the current command
+var currentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Get the command to run",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		cl, err := run.NewDefaultClient(ctx)
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			return
+		}
+
+		curr := cl.CurrentCommand()
+		fmt.Printf("%s", curr)
+	},
+}
+
+func init() {
+	InternalCmd.AddCommand(currentCmd)
+}

--- a/cmd/internal/current.go
+++ b/cmd/internal/current.go
@@ -20,8 +20,13 @@ var currentCmd = &cobra.Command{
 			return
 		}
 
-		curr := cl.CurrentCommand()
-		fmt.Printf("%s", curr)
+		state, err := cl.CurrentState()
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			return
+		}
+
+		fmt.Printf("%s", state.Command)
 	},
 }
 

--- a/cmd/internal/internal.go
+++ b/cmd/internal/internal.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// internalCmd represents the internal command
+var InternalCmd = &cobra.Command{
+	Use:    "internal",
+	Hidden: true,
+	Short:  "Internal commands not meant to be used by end users.",
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/getsavvyinc/savvy-cli/server/run"
@@ -21,16 +22,29 @@ var nextCmd = &cobra.Command{
 			return
 		}
 
-		curr := cl.CurrentCommand()
-		if curr != executedCommand {
-			return
-		}
-
-		idx, err := cl.NextCommand()
+		state, err := cl.CurrentState()
 		if err != nil {
 			display.ErrorWithSupportCTA(err)
-			return
+			os.Exit(1)
 		}
+
+		if state.Command != executedCommand {
+			fmt.Printf("%d", state.Index)
+		}
+
+		if err := cl.NextCommand(); err != nil {
+			display.ErrorWithSupportCTA(err)
+			os.Exit(1)
+		}
+
+		state, err = cl.CurrentState()
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			os.Exit(1)
+		}
+
+		// Required as arrays are 0-indexed
+		idx := state.Index + 1
 
 		fmt.Printf("%d", idx)
 	},

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -38,16 +38,12 @@ var nextCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		state, err = cl.CurrentState()
+		updated, err := cl.CurrentState()
 		if err != nil {
 			display.ErrorWithSupportCTA(err)
 			os.Exit(1)
 		}
-
-		// Required as arrays are 0-indexed
-		idx := state.Index + 1
-
-		fmt.Printf("%d", idx)
+		fmt.Printf("%d", updated.Index)
 	},
 }
 

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -30,6 +30,7 @@ var nextCmd = &cobra.Command{
 
 		if state.Command != executedCommand {
 			fmt.Printf("%d", state.Index)
+			return
 		}
 
 		if err := cl.NextCommand(); err != nil {

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/server/run"
+	"github.com/spf13/cobra"
+)
+
+// nextCmd represents the next command
+var nextCmd = &cobra.Command{
+	Use:    "next",
+	Hidden: true,
+	Short:  "Update runbook state to next step",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		cl, err := run.NewDefaultClient(ctx)
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			return
+		}
+
+		curr := cl.CurrentCommand()
+		if curr != executedCommand {
+			return
+		}
+
+		idx, err := cl.NextCommand()
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			return
+		}
+
+		fmt.Printf("%d", idx)
+	},
+}
+
+var executedCommand string
+
+func init() {
+	InternalCmd.AddCommand(nextCmd)
+
+	nextCmd.Flags().StringVarP(&executedCommand, "cmd", "c", "", "previously executed command")
+}

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// subcommandCmd represents the subcommand command
+var subcommandCmd = &cobra.Command{
+	Use:   "set-param",
+	Short: "Prompt the user to set one ore parameters for their runbook",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("subcommand called")
+	},
+}
+
+func init() {
+	InternalCmd.AddCommand(subcommandCmd)
+}

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
@@ -11,10 +14,68 @@ var subcommandCmd = &cobra.Command{
 	Use:   "set-param",
 	Short: "Prompt the user to set one ore parameters for their runbook",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("subcommand called")
+		ctx := cmd.Context()
+		fields := ParamFields(ctx, params)
+		var fs []huh.Field
+		for _, param := range params {
+			fs = append(fs, fields[param])
+		}
+
+		if len(fs) == 0 {
+			return
+		}
+
+		param := huh.NewGroup(fs...).Title(title)
+
+		if err := huh.NewForm(param).Run(); err != nil {
+			// TODO: handle error
+			panic(err)
+		}
+
+		for _, f := range fs {
+			i, ok := f.(*huh.Input)
+			if !ok {
+				continue
+			}
+			fmt.Println(i.GetKey(), i.GetValue())
+		}
 	},
 }
 
+var title string
+var params []string
+
 func init() {
 	InternalCmd.AddCommand(subcommandCmd)
+
+	// title flag
+	subcommandCmd.Flags().StringVarP(&title, "title", "t", "Set Params", "form title")
+	// params flag. This is a slice of strings
+	subcommandCmd.Flags().StringSliceVarP(&params, "params", "p", []string{}, "form params")
+}
+
+func ParamFields(ctx context.Context, params []string) map[string]huh.Field {
+	fields := map[string]huh.Field{}
+
+	for _, param := range params {
+		if _, ok := fields[param]; ok {
+			continue
+		}
+		title, desc := parseParam(param)
+		fields[param] = huh.NewInput().Title(title).Description(desc).Key(param)
+	}
+	return fields
+}
+
+const DefaultTitle = "Set Params"
+const DefaultDescription = ""
+
+func parseParam(param string) (string, string) {
+	if !strings.HasPrefix(param, "<") || !strings.HasSuffix(param, ">") {
+		return DefaultTitle, DefaultDescription
+	}
+
+	title := "Set " + param
+
+	return title, ""
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/getsavvyinc/savvy-cli/cmd/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +49,7 @@ func init() {
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.savvy.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debug mode")
+	rootCmd.AddCommand(internal.InternalCmd)
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/server/run"
 	"github.com/getsavvyinc/savvy-cli/shell"
 	"github.com/muesli/cancelreader"
 	"github.com/spf13/cobra"
@@ -88,7 +89,13 @@ func savvyRun(cmd *cobra.Command, args []string) {
 }
 
 func runRunbook(ctx context.Context, runbook *client.Runbook) error {
-	sh := shell.New("/tmp/savvy-socket")
+	rsrv, err := run.NewServerWithDefaultSocketPath(runbook)
+	if err != nil {
+		return err
+	}
+
+	sh := shell.New(rsrv.SocketPath())
+
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -443,8 +443,8 @@ SAVVY_NEXT_STEP=0
 # Set up a function to run the next command in the runbook when the user presses C-n
 savvy_runbook_runner() {
   if [[ "${SAVVY_CONTEXT}" == "run"  && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS[@]}" ]] ; then
-    next_step_idx=${SAVVY_NEXT_STEP}
-    READLINE_LINE="${SAVVY_COMMANDS[next_step_idx]}"
+    next_step=$(savvy internal current)
+    READLINE_LINE="${next_step}"
     READLINE_POINT=${#READLINE_LINE}
   fi
 }
@@ -454,9 +454,7 @@ savvy_run_pre_exec() {
   # we want the command as it was typed in.
   local cmd=$1
   if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -lt "${#SAVVY_COMMANDS[@]}" ]] ; then
-    if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
-      SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
-    fi
+    SAVVY_NEXT_STEP=$(savvy internal next --cmd="${cmd}")
   fi
 }
 
@@ -467,6 +465,7 @@ PROMPT_RED="\[$(tput setaf 1)\]"
 PROMPT_RESET="\[$(tput sgr0)\]"
 
 savvy_run_pre_cmd() {
+  # transorm 0 based index to 1 based index
   local display_step=$((SAVVY_NEXT_STEP+1))
   local size=${#SAVVY_COMMANDS[@]}
 

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -39,10 +39,6 @@ function __savvy_run_pre_exec__() {
   local cmd=$1
   if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
     SAVVY_NEXT_STEP=$(savvy internal next --cmd="${cmd}")
-    echo "SAVVY_NEXT_STEP: ${SAVVY_NEXT_STEP}"
-    #if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
-      #SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
-    #fi
   fi
 }
 
@@ -68,7 +64,6 @@ function __savvy_run_pre_cmd__() {
 function __savvy_runbook_runner__() {
 
   if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
-    #next_step_idx=${SAVVY_NEXT_STEP}
     run_cmd=$(savvy internal current)
     BUFFER="${run_cmd}"
     zle end-of-line  # Accept the line for editing

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -38,9 +38,10 @@ function __savvy_run_pre_exec__() {
   # we want the command as it was typed in.
   local cmd=$1
   if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
-    if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
-      SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
-    fi
+    SAVVY_NEXT_STEP=$(savvy internal next --cmd="${cmd}")
+    #if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
+      #SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
+    #fi
   fi
 }
 
@@ -64,8 +65,9 @@ function __savvy_run_pre_cmd__() {
 function __savvy_runbook_runner__() {
 
   if [[ "${SAVVY_CONTEXT}" == "run"  && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS}" ]] ; then
-    next_step_idx=${SAVVY_NEXT_STEP}
-    BUFFER="${SAVVY_COMMANDS[next_step_idx]}"
+    #next_step_idx=${SAVVY_NEXT_STEP}
+    cmd=$(savvy internal fetch)
+    BUFFER="${cmd}"
     zle end-of-line  # Accept the line for editing
   fi
 }

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -66,7 +66,7 @@ function __savvy_runbook_runner__() {
 
   if [[ "${SAVVY_CONTEXT}" == "run"  && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS}" ]] ; then
     #next_step_idx=${SAVVY_NEXT_STEP}
-    cmd=$(savvy internal fetch)
+    cmd=$(savvy internal current)
     BUFFER="${cmd}"
     zle end-of-line  # Accept the line for editing
   fi

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -66,8 +66,8 @@ function __savvy_runbook_runner__() {
 
   if [[ "${SAVVY_CONTEXT}" == "run"  && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS}" ]] ; then
     #next_step_idx=${SAVVY_NEXT_STEP}
-    cmd=$(savvy internal current)
-    BUFFER="${cmd}"
+    run_cmd=$(savvy internal current)
+    BUFFER="${run_cmd}"
     zle end-of-line  # Accept the line for editing
   fi
 }

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -83,7 +83,7 @@ SAVVY_RUN_CURR=""
 SAVVY_NEXT_STEP=1
 if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
   zle -N zle-line-init __savvy_runbook_runner__
-  add-zle-hook-widget line-init __savvy_runbook_runner__
+  # add-zle-hook-widget line-init __savvy_runbook_runner__
   # SAVVY_RUNBOOK_COMMANDS is a list of commands that savvy should run in the run context
   SAVVY_COMMANDS=("${(@s:COMMA:)SAVVY_RUNBOOK_COMMANDS}")
   SAVVY_RUN_CURR="${SAVVY_RUNBOOK_ALIAS}"

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -39,6 +39,7 @@ function __savvy_run_pre_exec__() {
   local cmd=$1
   if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
     SAVVY_NEXT_STEP=$(savvy internal next --cmd="${cmd}")
+    echo "SAVVY_NEXT_STEP: ${SAVVY_NEXT_STEP}"
     #if [[ "${cmd}" == "${SAVVY_COMMANDS[SAVVY_NEXT_STEP]}" ]] ; then
       #SAVVY_NEXT_STEP=$((SAVVY_NEXT_STEP+1))
     #fi
@@ -64,7 +65,7 @@ function __savvy_run_pre_cmd__() {
 
 function __savvy_runbook_runner__() {
 
-  if [[ "${SAVVY_CONTEXT}" == "run"  && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS}" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
     #next_step_idx=${SAVVY_NEXT_STEP}
     run_cmd=$(savvy internal current)
     BUFFER="${run_cmd}"

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -51,13 +51,15 @@ function __savvy_run_pre_cmd__() {
     PS1="${orignal_ps1}"$'(%F{red}savvy run %f'" ${SAVVY_RUN_CURR})"" "
   fi
 
-  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -gt "${#SAVVY_COMMANDS}" ]] ; then
+  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -ge "${#SAVVY_COMMANDS}" ]] ; then
     # space at the end is important
     PS1="${orignal_ps1}"$'%F{green} done%f \U1f60e '
   fi
 
-  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -le "${#SAVVY_COMMANDS}" && "${#SAVVY_COMMANDS}" -gt 0 ]] ; then
-    RPS1="${original_rps1} %F{green}(${SAVVY_NEXT_STEP}/${#SAVVY_COMMANDS})"
+  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -lt "${#SAVVY_COMMANDS}" && "${#SAVVY_COMMANDS}" -gt 0 ]] ; then
+    # translate 0-based index to 1-based index
+    num=$((SAVVY_NEXT_STEP+1))
+    RPS1="${original_rps1} %F{green}(${num}/${#SAVVY_COMMANDS})"
   else 
     RPS1="${original_rps1}"
   fi
@@ -83,7 +85,7 @@ original_rps1=$RPS1
 
 SAVVY_COMMANDS=()
 SAVVY_RUN_CURR=""
-SAVVY_NEXT_STEP=1
+SAVVY_NEXT_STEP=0
 if [[ "${SAVVY_CONTEXT}" == "run" ]] ; then
   zle -N zle-line-init __savvy_runbook_runner__
   # add-zle-hook-widget line-init __savvy_runbook_runner__

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -77,7 +77,7 @@ var writeCmd = &cobra.Command{
 			if fileExists(filepath.Join(dirPath, filename)) {
 				var confirmation bool
 				confirmOverwrite := huh.NewConfirm().Title("File already exists").Description("Overwrite existing file?").Value(&confirmation)
-				if err := huh.NewForm(huh.NewGroup(confirmOverwrite)).Run(); err != nil {
+				if err := huh.NewForm(huh.NewGroup(confirmOverwrite)).WithTheme(huh.ThemeDracula()).Run(); err != nil {
 					display.FatalErrWithSupportCTA(err)
 					return
 				}

--- a/server/cleanup/permission.go
+++ b/server/cleanup/permission.go
@@ -1,0 +1,21 @@
+package cleanup
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/getsavvyinc/savvy-cli/server/mode"
+)
+
+func GetPermission(m mode.Mode) (bool, error) {
+	var confirmation bool
+	confirmCleanup := huh.NewConfirm().
+		Title(fmt.Sprintf("Multiple %s sessions detected", m)).
+		Affirmative("Continue here and kill other sessions").
+		Negative("Quit this session").
+		Value(&confirmation)
+	if err := huh.NewForm(huh.NewGroup(confirmCleanup)).Run(); err != nil {
+		return false, err
+	}
+	return confirmation, nil
+}

--- a/server/client.go
+++ b/server/client.go
@@ -19,7 +19,7 @@ type Client interface {
 
 type ShutdownSender interface {
 	// Shutdown tells the server to shutdown.
-	SendShutdown()
+	SendShutdown() error
 }
 
 func NewDefaultClient(ctx context.Context) (Client, error) {
@@ -40,10 +40,10 @@ type client struct {
 
 var _ Client = &client{}
 
-func (c *client) SendShutdown() {
+func (c *client) SendShutdown() error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
-		return
+		return err
 	}
 	defer conn.Close()
 
@@ -51,7 +51,7 @@ func (c *client) SendShutdown() {
 		Command: shutdownCommand,
 	}
 
-	json.NewEncoder(conn).Encode(data)
+	return json.NewEncoder(conn).Encode(data)
 }
 
 func (c *client) SendFileInfo(filePath string) error {

--- a/server/client.go
+++ b/server/client.go
@@ -14,7 +14,11 @@ import (
 type Client interface {
 	// SendFileInfo tells the server to read the file at the given path
 	SendFileInfo(filePath string) error
-	// SendShutdown tells the server to shutdown.
+	ShutdownSender
+}
+
+type ShutdownSender interface {
+	// Shutdown tells the server to shutdown.
 	SendShutdown()
 }
 

--- a/server/client.go
+++ b/server/client.go
@@ -24,6 +24,12 @@ func NewDefaultClient(ctx context.Context) (Client, error) {
 	}, nil
 }
 
+func NewClient(ctx context.Context, socketPath string) (Client, error) {
+	return &client{
+		socketPath: socketPath,
+	}, nil
+}
+
 type client struct {
 	socketPath string
 }

--- a/server/mode/mode.go
+++ b/server/mode/mode.go
@@ -1,0 +1,19 @@
+package mode
+
+type Mode int
+
+const (
+	Record Mode = iota
+	Run
+)
+
+func (mode Mode) String() string {
+	switch mode {
+	case Record:
+		return "recording"
+	case Run:
+		return "run"
+	default:
+		return ""
+	}
+}

--- a/server/run/client.go
+++ b/server/run/client.go
@@ -1,0 +1,95 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+
+	"github.com/getsavvyinc/savvy-cli/server"
+)
+
+type Client interface {
+	server.ShutdownSender
+	NextCommand() error
+	PreviousCommand() error
+	FetchCommand() string
+}
+
+func NewDefaultClient(ctx context.Context) (Client, error) {
+	return NewClient(ctx, DefaultRunSocketPath)
+}
+
+type client struct {
+	socketPath string
+}
+
+var _ Client = &client{}
+
+func NewClient(ctx context.Context, socketPath string) (Client, error) {
+	return &client{
+		socketPath: socketPath,
+	}, nil
+}
+
+func (c *client) SendShutdown() error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data := RunCommand{
+		Command: shutdownCommand,
+	}
+
+	return json.NewEncoder(conn).Encode(data)
+}
+
+func (c *client) NextCommand() error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data := RunCommand{
+		Command: nextCommand,
+	}
+
+	return json.NewEncoder(conn).Encode(data)
+}
+
+func (c *client) PreviousCommand() error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return err
+	}
+
+	data := RunCommand{
+		Command: previousCommand,
+	}
+
+	return json.NewEncoder(conn).Encode(data)
+}
+
+func (c *client) FetchCommand() string {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return err.Error()
+	}
+
+	data := RunCommand{
+		Command: fetchCommand,
+	}
+
+	if err := json.NewEncoder(conn).Encode(data); err != nil {
+		return err.Error()
+	}
+
+	var response RunCommand
+	if err := json.NewDecoder(conn).Decode(&response); err != nil {
+		return err.Error()
+	}
+
+	return response.Command
+}

--- a/server/run/client.go
+++ b/server/run/client.go
@@ -68,6 +68,7 @@ func (c *client) PreviousCommand() error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	data := RunCommand{
 		Command: previousCommand,
@@ -81,6 +82,7 @@ func (c *client) CurrentState() (*State, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer conn.Close()
 
 	data := RunCommand{
 		Command: currentCommand,
@@ -94,6 +96,5 @@ func (c *client) CurrentState() (*State, error) {
 	if err := json.NewDecoder(conn).Decode(&response); err != nil {
 		return nil, err
 	}
-
 	return &response, nil
 }

--- a/server/run/client.go
+++ b/server/run/client.go
@@ -45,6 +45,10 @@ func (c *client) SendShutdown() error {
 	return json.NewEncoder(conn).Encode(data)
 }
 
+// NOTE: If we don't wait for the response and if the server has go-routines for each connection, we might have race conditions.
+// e.g: c.NextCommand() and c.CurrentState() might be called sequentially, but the server might schedule the go-routines such that c.CurrentState() completes before c.NextCommand()
+// Then we might get the wrong state.
+// To avoid this, for now, the server is single threaded.
 func (c *client) NextCommand() error {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -2,10 +2,14 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"github.com/getsavvyinc/savvy-cli/server"
@@ -17,7 +21,10 @@ type RunServer struct {
 	socketPath string
 	logger     *slog.Logger
 	listener   net.Listener
-	commands   []*RunCommand
+
+	mu        sync.Mutex
+	currIndex int
+	commands  []*RunCommand
 
 	closed atomic.Bool
 }
@@ -62,26 +69,109 @@ var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions
 func newRunServer(socketPath string, commands []*RunCommand, opts ...Option) (*RunServer, error) {
 	if fileInfo, _ := os.Stat(socketPath); fileInfo != nil {
 
-		cleanup, cerr := cleanup.GetPermission(mode.Run)
+		cleanupOK, cerr := cleanup.GetPermission(mode.Run)
 		if cerr != nil {
 			return nil, cerr
 		}
 
-		if !cleanup {
+		if !cleanupOK {
 			return nil, server.ErrAbortRecording
 		}
 
 		cleanupSocket(socketPath)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener: %w", err)
 	}
 
 	rs := &RunServer{
 		socketPath: socketPath,
 		logger:     defaultLogger,
 		commands:   commands,
+		listener:   listener,
 	}
 
 	for _, opt := range opts {
 		opt(rs)
 	}
 	return rs, nil
+}
+
+func (rs *RunServer) Close() error {
+	if rs.closed.Load() {
+		return nil
+	}
+	rs.closed.Store(true)
+	return rs.listener.Close()
+}
+
+func (rs *RunServer) handleConnection(c net.Conn) {
+	defer c.Close()
+
+	bs, err := io.ReadAll(c)
+	if err != nil {
+		rs.logger.Error("failed to read from connection: %s\n", err)
+		return
+	}
+
+	var data RunCommand
+	if err := json.Unmarshal(bs, &data); err != nil {
+		rs.logger.Error("failed to unmarshal data", "error", err.Error(), "component", "run", "input", string(bs))
+		return
+	}
+
+	if data.IsShutdown() {
+		rs.Close()
+		return
+	}
+
+	cmd := data.Command
+	rs.handleCommand(cmd, c)
+}
+
+func (rs *RunServer) handleCommand(cmd string, c net.Conn) {
+	switch cmd {
+	case shutdownCommand:
+		rs.Close()
+	case nextCommand:
+		rs.mu.Lock()
+		rs.currIndex++
+		if rs.currIndex >= len(rs.commands) {
+			rs.currIndex = len(rs.commands) - 1
+		}
+		rs.mu.Unlock()
+	case previousCommand:
+		rs.mu.Lock()
+		rs.currIndex--
+		if rs.currIndex < 0 {
+			rs.currIndex = 0
+		}
+		rs.mu.Unlock()
+	case fetchCommand:
+		rs.mu.Lock()
+		if rs.currIndex >= len(rs.commands) {
+			rs.currIndex = len(rs.commands) - 1
+		}
+		if rs.currIndex < 0 {
+			rs.currIndex = 0
+		}
+		cmd := rs.commands[rs.currIndex]
+		rs.mu.Unlock()
+		rs.logger.Debug("fetching command", "command", cmd)
+		json.NewEncoder(c).Encode(cmd)
+	default:
+		rs.logger.Debug("unknown command", "command", cmd)
+	}
+}
+
+const (
+	shutdownCommand = "savvy shutdown"
+	nextCommand     = "savvy internal next"
+	previousCommand = "savvy internal prev"
+	fetchCommand    = "savvy internal fetch"
+)
+
+func (rc *RunCommand) IsShutdown() bool {
+	return rc.Command == shutdownCommand
 }

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -160,9 +160,7 @@ func (rs *RunServer) handleCommand(cmd string, c net.Conn) {
 	case shutdownCommand:
 		rs.Close()
 	case nextCommand:
-		rs.logger.Info("before inc: ", "currIndex", rs.currIndex)
 		rs.currIndex += 1
-		rs.logger.Info("after inc: ", "currIndex", rs.currIndex)
 		// NOTE: we intentionally allow currIndex to = len(rs.commands) that's how we know we're done
 		if rs.currIndex > len(rs.commands) {
 			rs.currIndex = len(rs.commands)

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/getsavvyinc/savvy-cli/client"
+	savvy_client "github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/server"
 	"github.com/getsavvyinc/savvy-cli/server/cleanup"
 	"github.com/getsavvyinc/savvy-cli/server/mode"
@@ -62,13 +62,13 @@ func cleanupSocket(socketPath string) error {
 	return nil
 }
 
-func NewServerWithDefaultSocketPath(rb *client.Runbook, opts ...Option) (*RunServer, error) {
+func NewServerWithDefaultSocketPath(rb *savvy_client.Runbook, opts ...Option) (*RunServer, error) {
 	return newRunServer(DefaultRunSocketPath, rb, opts...)
 }
 
 var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
 
-func newRunServer(socketPath string, rb *client.Runbook, opts ...Option) (*RunServer, error) {
+func newRunServer(socketPath string, rb *savvy_client.Runbook, opts ...Option) (*RunServer, error) {
 	if fileInfo, _ := os.Stat(socketPath); fileInfo != nil {
 
 		cleanupOK, cerr := cleanup.GetPermission(mode.Run)
@@ -89,7 +89,7 @@ func newRunServer(socketPath string, rb *client.Runbook, opts ...Option) (*RunSe
 
 	steps := rb.Steps
 
-	cmds := slice.Map(steps, func(step client.Step) *RunCommand {
+	cmds := slice.Map(steps, func(step savvy_client.Step) *RunCommand {
 		return &RunCommand{
 			Command: step.Command,
 		}

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -1,0 +1,87 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"os"
+	"sync/atomic"
+
+	"github.com/getsavvyinc/savvy-cli/server"
+	"github.com/getsavvyinc/savvy-cli/server/cleanup"
+	"github.com/getsavvyinc/savvy-cli/server/mode"
+)
+
+type RunServer struct {
+	socketPath string
+	logger     *slog.Logger
+	listener   net.Listener
+	commands   []*RunCommand
+
+	closed atomic.Bool
+}
+
+type RunCommand struct {
+	Command string `json:"command,omitempty"`
+}
+
+const DefaultRunSocketPath = "/tmp/savvy-run-socket"
+
+var ErrStartingRunSession = errors.New("failed to start run session")
+
+type Option func(s *RunServer)
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *RunServer) {
+		s.logger = logger
+	}
+}
+
+// cleanupSocket is an internal function.
+// It is the callers responsibility to ensure the socketPath exists.
+func cleanupSocket(socketPath string) error {
+	cl, err := server.NewClient(context.Background(), socketPath)
+	if err != nil {
+		return err
+	}
+	cl.SendShutdown()
+
+	if err := os.Remove(socketPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewServerWithDefaultSocketPath(commands []*RunCommand, opts ...Option) (*RunServer, error) {
+	return newRunServer(DefaultRunSocketPath, commands, opts...)
+}
+
+var defaultLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{}))
+
+func newRunServer(socketPath string, commands []*RunCommand, opts ...Option) (*RunServer, error) {
+	if fileInfo, _ := os.Stat(socketPath); fileInfo != nil {
+
+		cleanup, cerr := cleanup.GetPermission(mode.Run)
+		if cerr != nil {
+			return nil, cerr
+		}
+
+		if !cleanup {
+			return nil, server.ErrAbortRecording
+		}
+
+		cleanupSocket(socketPath)
+	}
+
+	rs := &RunServer{
+		socketPath: socketPath,
+		logger:     defaultLogger,
+		commands:   commands,
+	}
+
+	for _, opt := range opts {
+		opt(rs)
+	}
+	return rs, nil
+}

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -189,11 +188,7 @@ func (rs *RunServer) handleCommand(cmd string, c net.Conn) {
 		response.Index = rs.currIndex
 		rs.mu.Unlock()
 		rs.logger.Debug("fetching command", "command", cmd)
-		bs, _ := json.Marshal(response)
-		bs = append(bs, '\n')
-		writer := bufio.NewWriter(c)
-		writer.Write(bs)
-		writer.Flush()
+		json.NewEncoder(c).Encode(response)
 	default:
 		rs.logger.Debug("unknown command", "command", cmd)
 	}

--- a/server/run/run_test.go
+++ b/server/run/run_test.go
@@ -1,0 +1,79 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	savvy_client "github.com/getsavvyinc/savvy-cli/client"
+	"github.com/getsavvyinc/savvy-cli/idgen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunServer(t *testing.T) {
+	rb := &savvy_client.Runbook{
+		Title: "test",
+		Steps: []savvy_client.Step{
+			{
+				Command: "idx_0",
+			},
+			{
+				Command: "idx_1",
+			},
+			{
+				Command: "idx_2",
+			},
+		},
+	}
+
+	socketPath := "/tmp/savvy-run-test-" + idgen.New("tst") + ".sock"
+
+	srv, err := NewServerWithSocketPath(socketPath, rb)
+	// test server setup
+	assert.Nil(t, err)
+	assert.NotNil(t, srv)
+	assert.Equal(t, socketPath, srv.SocketPath())
+	assert.Len(t, srv.Commands(), 3)
+
+	assert.Equal(t, "idx_0", srv.Commands()[0].Command)
+	assert.Equal(t, "idx_1", srv.Commands()[1].Command)
+	assert.Equal(t, "idx_2", srv.Commands()[2].Command)
+
+	ctx := context.Background()
+	cl, err := NewClient(ctx, srv.SocketPath())
+	assert.Nil(t, err)
+	assert.NotNil(t, cl)
+
+	t.Cleanup(func() { assert.NoError(t, srv.Close()) })
+
+	go srv.ListenAndServe()
+
+	t.Run("TestCurrentCommand", func(t *testing.T) {
+		// test current command
+		st, err := cl.CurrentState()
+		assert.NoError(t, err)
+		assert.NotNil(t, st)
+		assert.Equal(t, "idx_0", st.Command)
+
+		t.Run("TestCurrentCommandIdempotent", func(t *testing.T) {
+			// test current command
+			st, err := cl.CurrentState()
+			assert.NoError(t, err)
+			assert.NotNil(t, st)
+			assert.Equal(t, "idx_0", st.Command)
+		})
+	})
+	t.Run("TestNextCommand", func(t *testing.T) {
+		st, err := cl.CurrentState()
+		assert.NoError(t, err)
+		assert.NotNil(t, st)
+		assert.Zero(t, st.Index)
+
+		assert.NoError(t, cl.NextCommand())
+
+		st, err = cl.CurrentState()
+		assert.NoError(t, err)
+		assert.NotNil(t, st)
+		assert.Equal(t, 1, st.Index)
+		assert.Equal(t, "idx_1", st.Command)
+	})
+}


### PR DESCRIPTION
- **cmd/internal: setup internal cmds**
- **parse params**
- **server/client: Create client for any socket path**
- **server: DRY cleanup socket committed**
- **client: Add a shutdown interface**
- **server/run: Add a run server**
- **savvy.zsh: only use zle to trigger runner**
- **server/client: SendShutdown returns an err**
- **server/run: Update state based on commands**
- **server/run: Add client for run server**
- **cmd/run: use runServer to coordinate state**
- **server/run: disambiguate client struct from pkg**
- **cmd/internal: impl current and next**
- **change return data for next and current**
- **cmd/history: handle err starting record server**
- **run: start server**
- **server/run: read json messages instead of waiting for client to close the conn**
- **close client conn when done**
- **savvy.zsh: use internal commands to run runbooks**
- **cmd/next: return immediately if no prev command**
- **server/run: return val using json encoder**
- **server/run: allow idx == len(commands)**
- **debug: savvy.zsh display next**
- **add tests**
- **setup/savvy.zsh: use 0 based arrays everywhere except when displaying step count**
- **internal/next: return 0 based array idx**
- **server/run: rm debug logs**
- **setup/savvy.zsh: cleanup debug logs**
- **server/run: Add note about why the run server is single threaded**
- **cmd/setup/bash-preexec.sh: impl run hooks with savvy internal cmds**
- **cmd/write: dracula shows better on light terminals**
