### PR TITLE
Add support for runbook parameterization

### DIFF
--- a/cmd/internal/current.go
+++ b/cmd/internal/current.go
@@ -26,7 +26,7 @@ var currentCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("%s", state.Command)
+		fmt.Printf("%s", state.CommandWithSetParams())
 	},
 }
 

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -28,7 +28,7 @@ var nextCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if state.Command != executedCommand {
+		if state.CommandWithSetParams() != executedCommand {
 			fmt.Printf("%d", state.Index)
 			return
 		}

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -3,11 +3,11 @@ package internal
 import (
 	"context"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/param"
 	"github.com/getsavvyinc/savvy-cli/server/run"
 	"github.com/getsavvyinc/savvy-cli/slice"
 	"github.com/spf13/cobra"
@@ -32,7 +32,7 @@ var subcommandCmd = &cobra.Command{
 		}
 
 		command := state.Command
-		params := extractParams(command)
+		params := param.Extract(command)
 		// Exit early
 		if len(params) == 0 {
 			return
@@ -83,22 +83,6 @@ var subcommandCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
-}
-
-var paramRegex = regexp.MustCompile(`<([a-zA-Z0-9-_]+)>`)
-
-func extractParams(input string) []string {
-	// Define a regular expression to match parameters in the form of <alphanumericchars>
-	matches := paramRegex.FindAllStringSubmatch(input, -1)
-
-	// Extract the matched parameters
-	var params []string
-	for _, match := range matches {
-		if len(match) >= 1 {
-			params = append(params, match[0])
-		}
-	}
-	return params
 }
 
 var title string

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -9,7 +9,6 @@ import (
 	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/getsavvyinc/savvy-cli/param"
 	"github.com/getsavvyinc/savvy-cli/server/run"
-	"github.com/getsavvyinc/savvy-cli/slice"
 	"github.com/spf13/cobra"
 )
 
@@ -31,23 +30,14 @@ var subcommandCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		command := state.Command
+		command := state.CommandWithSetParams()
 		params := param.Extract(command)
 		// Exit early
 		if len(params) == 0 {
 			return
 		}
 
-		unsetParams := slice.Filter(params, func(p string) bool {
-			_, ok := state.Params[p]
-			return ok
-		})
-
-		if len(unsetParams) == 0 {
-			return
-		}
-
-		fields := ParamFields(ctx, unsetParams)
+		fields := ParamFields(ctx, params)
 
 		var fs []huh.Field
 		for _, param := range params {
@@ -58,9 +48,9 @@ var subcommandCmd = &cobra.Command{
 			return
 		}
 
-		param := huh.NewGroup(fs...).Title(title)
+		paramGroup := huh.NewGroup(fs...).Title(title)
 
-		if err := huh.NewForm(param).Run(); err != nil {
+		if err := huh.NewForm(paramGroup).Run(); err != nil {
 			display.ErrorWithSupportCTA(err)
 			os.Exit(1)
 		}

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -48,7 +48,7 @@ var subcommandCmd = &cobra.Command{
 			return
 		}
 
-		paramGroup := huh.NewGroup(fs...).Title(title)
+		paramGroup := huh.NewGroup(fs...).Title(command)
 
 		if err := huh.NewForm(paramGroup).Run(); err != nil {
 			display.ErrorWithSupportCTA(err)
@@ -80,11 +80,6 @@ var params []string
 
 func init() {
 	InternalCmd.AddCommand(subcommandCmd)
-
-	// title flag
-	subcommandCmd.Flags().StringVarP(&title, "title", "t", "Set Params", "form title")
-	// params flag. This is a slice of strings
-	subcommandCmd.Flags().StringSliceVarP(&params, "params", "p", []string{}, "form params")
 }
 
 func ParamFields(ctx context.Context, params []string) map[string]huh.Field {

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -40,6 +40,8 @@ var subcommandCmd = &cobra.Command{
 		fields := ParamFields(ctx, params)
 
 		var fs []huh.Field
+		note := huh.NewNote().Title(command).Description("Set Parameteres")
+		fs = append(fs, note)
 		for _, param := range params {
 			fs = append(fs, fields[param])
 		}

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -48,7 +48,7 @@ var subcommandCmd = &cobra.Command{
 			return
 		}
 
-		paramGroup := huh.NewGroup(fs...).Title(command)
+		paramGroup := huh.NewGroup(fs...).Title(command).WithTheme(huh.ThemeDracula())
 
 		if err := huh.NewForm(paramGroup).Run(); err != nil {
 			display.ErrorWithSupportCTA(err)

--- a/cmd/internal/set-param.go
+++ b/cmd/internal/set-param.go
@@ -40,7 +40,8 @@ var subcommandCmd = &cobra.Command{
 		fields := ParamFields(ctx, params)
 
 		var fs []huh.Field
-		note := huh.NewNote().Title(command).Description("Set Parameteres")
+		description := "Set parameters for the command"
+		note := huh.NewNote().Title(command).Description(description)
 		fs = append(fs, note)
 		for _, param := range params {
 			fs = append(fs, fields[param])

--- a/cmd/internal/set-param_test.go
+++ b/cmd/internal/set-param_test.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractParams(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:  "no params",
+			input: "No parameters here!",
+		},
+		{
+			name:     "param with alphabets",
+			input:    `jobrunner.sh --file="<file>"`,
+			expected: []string{"<file>"},
+		},
+		{
+			name:     "param with numbers",
+			input:    `script --id="<id1>" --name="<name2>"`,
+			expected: []string{"<id1>", "<name2>"},
+		},
+		{
+			name:     "incomplete param",
+			input:    "Edge case with incomplete <param and another<param2>",
+			expected: []string{"<param2>"},
+		},
+		{
+			name:     "param with hyphen, underscore",
+			input:    `script --id="<id-1>" --name="<name_2>"`,
+			expected: []string{"<id-1>", "<name_2>"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := extractParams(tc.input)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected %v; got %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/cmd/setup/bash-preexec.sh
+++ b/cmd/setup/bash-preexec.sh
@@ -477,6 +477,10 @@ savvy_run_pre_cmd() {
     # space at the end is important
     PS1="${orignal_ps1} ${PROMPT_GREEN}done${PROMPT_RESET}"$' \U1f60e '
   fi
+
+  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -lt "${size}" ]] ; then
+    savvy internal set-param
+  fi
 }
 
 

--- a/cmd/setup/savvy.zsh
+++ b/cmd/setup/savvy.zsh
@@ -59,6 +59,10 @@ function __savvy_run_pre_cmd__() {
   else 
     RPS1="${original_rps1}"
   fi
+
+  if [[ "${SAVVY_CONTEXT}" == "run" && "${SAVVY_NEXT_STEP}" -lt "${#SAVVY_COMMANDS}" ]] ; then
+    savvy internal set-param
+  fi
 }
 
 function __savvy_runbook_runner__() {

--- a/param/param.go
+++ b/param/param.go
@@ -1,0 +1,19 @@
+package param
+
+import "regexp"
+
+var paramRegex = regexp.MustCompile(`<([a-zA-Z0-9-_]+)>`)
+
+func Extract(input string) []string {
+	// Define a regular expression to match parameters in the form of <alphanumericchars>
+	matches := paramRegex.FindAllStringSubmatch(input, -1)
+
+	// Extract the matched parameters
+	var params []string
+	for _, match := range matches {
+		if len(match) >= 1 {
+			params = append(params, match[0])
+		}
+	}
+	return params
+}

--- a/param/param.go
+++ b/param/param.go
@@ -8,10 +8,15 @@ func Extract(input string) []string {
 	// Define a regular expression to match parameters in the form of <alphanumericchars>
 	matches := paramRegex.FindAllStringSubmatch(input, -1)
 
+	seen := make(map[string]struct{})
 	// Extract the matched parameters
 	var params []string
 	for _, match := range matches {
 		if len(match) >= 1 {
+			if _, ok := seen[match[0]]; ok {
+				continue
+			}
+			seen[match[0]] = struct{}{}
 			params = append(params, match[0])
 		}
 	}

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -1,8 +1,10 @@
-package internal
+package param_test
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/getsavvyinc/savvy-cli/param"
 )
 
 func TestExtractParams(t *testing.T) {
@@ -40,7 +42,7 @@ func TestExtractParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := extractParams(tc.input)
+			actual := param.Extract(tc.input)
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("expected %v; got %v", tc.expected, actual)
 			}

--- a/param/param_test.go
+++ b/param/param_test.go
@@ -38,6 +38,11 @@ func TestExtractParams(t *testing.T) {
 			input:    `script --id="<id-1>" --name="<name_2>"`,
 			expected: []string{"<id-1>", "<name_2>"},
 		},
+		{
+			name:     "dedupe params",
+			input:    `script --id="<id-1>" --name="<id-1>"`,
+			expected: []string{"<id-1>"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/server/run/client.go
+++ b/server/run/client.go
@@ -13,6 +13,7 @@ type Client interface {
 	NextCommand() error
 	PreviousCommand() error
 	CurrentState() (*State, error)
+	SetParams(params map[string]string) error
 }
 
 func NewDefaultClient(ctx context.Context) (Client, error) {
@@ -79,6 +80,24 @@ func (c *client) PreviousCommand() error {
 	}
 
 	return json.NewEncoder(conn).Encode(data)
+}
+
+func (c *client) SetParams(params map[string]string) error {
+	conn, err := net.Dial("unix", c.socketPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data := RunCommand{
+		Command: paramCommand,
+		Params:  params,
+	}
+
+	if err := json.NewEncoder(conn).Encode(data); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *client) CurrentState() (*State, error) {

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync/atomic"
 
 	savvy_client "github.com/getsavvyinc/savvy-cli/client"
@@ -40,7 +41,15 @@ type State struct {
 }
 
 func (s *State) CommandWithSetParams() string {
-	return s.Command
+	if s.Params == nil || len(s.Params) == 0 {
+		return s.Command
+	}
+
+	cmd := s.Command
+	for k, v := range s.Params {
+		cmd = strings.ReplaceAll(cmd, k, v)
+	}
+	return cmd
 }
 
 const DefaultRunSocketPath = "/tmp/savvy-run.sock"

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -39,6 +39,10 @@ type State struct {
 	Params  map[string]string `json:"params"`
 }
 
+func (s *State) CommandWithSetParams() string {
+	return s.Command
+}
+
 const DefaultRunSocketPath = "/tmp/savvy-run.sock"
 
 var ErrStartingRunSession = errors.New("failed to start run session")

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -36,7 +36,7 @@ type State struct {
 	Index   int    `json:"index"`
 }
 
-const DefaultRunSocketPath = "/tmp/savvy-run-socket"
+const DefaultRunSocketPath = "/tmp/savvy-run.sock"
 
 var ErrStartingRunSession = errors.New("failed to start run session")
 

--- a/server/run/run_test.go
+++ b/server/run/run_test.go
@@ -135,3 +135,63 @@ func newTestServerWithClient(t *testing.T, rb *savvy_client.Runbook) (*RunServer
 	go srv.ListenAndServe()
 	return srv, cl, srv.Close
 }
+
+func TestCommandWithSetParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		state    *State
+		expected string
+	}{
+		{
+			name: "no params",
+			state: &State{
+				Command: "echo hello",
+				Index:   0,
+				Params:  nil,
+			},
+			expected: "echo hello",
+		},
+		{
+			name: "no params in command",
+			state: &State{
+				Command: "echo hello",
+				Index:   0,
+				Params:  map[string]string{"<param>": "world"},
+			},
+			expected: "echo hello",
+		},
+		{
+			name: "single param",
+			state: &State{
+				Command: "echo <param>",
+				Index:   0,
+				Params:  map[string]string{"<param>": "world"},
+			},
+			expected: "echo world",
+		},
+		{
+			name: "multiple instance of same param",
+			state: &State{
+				Command: "echo <param> <param>",
+				Index:   0,
+				Params:  map[string]string{"<param>": "world"},
+			},
+			expected: "echo world world",
+		},
+		{
+			name: "multiple params",
+			state: &State{
+				Command: "echo <param1> <param2>",
+				Index:   0,
+				Params:  map[string]string{"<param1>": "hello", "<param2>": "world"},
+			},
+			expected: "echo hello world",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.state.CommandWithSetParams())
+		})
+	}
+}

--- a/server/run/run_test.go
+++ b/server/run/run_test.go
@@ -37,14 +37,14 @@ func TestRunServer(t *testing.T) {
 		st, err := cl.CurrentState()
 		assert.NoError(t, err)
 		assert.NotNil(t, st)
-		assert.Equal(t, "idx_0", st.Command)
+		assert.Equal(t, "idx_0", st.CommandWithSetParams())
 
 		t.Run("TestCurrentCommandIdempotent", func(t *testing.T) {
 			// test current command
 			st, err := cl.CurrentState()
 			assert.NoError(t, err)
 			assert.NotNil(t, st)
-			assert.Equal(t, "idx_0", st.Command)
+			assert.Equal(t, "idx_0", st.CommandWithSetParams())
 		})
 	})
 	t.Run("TestNextCommand", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestRunServer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, st)
 		assert.Equal(t, 1, st.Index)
-		assert.Equal(t, "idx_1", st.Command)
+		assert.Equal(t, "idx_1", st.CommandWithSetParams())
 	})
 	t.Run("TestParam", func(t *testing.T) {
 		_, cl, cleanup := newTestServerWithClient(t, rb)
@@ -97,7 +97,7 @@ func TestRunServer(t *testing.T) {
 					assert.NoError(t, err)
 					assert.NotNil(t, st)
 					assert.Equal(t, 1, st.Index)
-					assert.Equal(t, "idx_1", st.Command)
+					assert.Equal(t, "idx_1", st.CommandWithSetParams())
 					assert.Len(t, st.Params, 1)
 					assert.Equal(t, "value", st.Params["<param>"])
 				})

--- a/server/run/run_test.go
+++ b/server/run/run_test.go
@@ -73,6 +73,47 @@ func TestRunServer(t *testing.T) {
 		assert.NotNil(t, st)
 		assert.Zero(t, st.Index)
 		assert.Len(t, st.Params, 0)
+		t.Run("TestSetParam", func(t *testing.T) {
+			assert.NoError(t, cl.SetParams(map[string]string{"<param>": "value"}))
+			st, err := cl.CurrentState()
+			assert.NoError(t, err)
+			assert.NotNil(t, st)
+			assert.Zero(t, st.Index)
+			assert.Len(t, st.Params, 1)
+			assert.Equal(t, "value", st.Params["<param>"])
+			t.Run("TestNoOverwriteParam", func(t *testing.T) {
+				assert.NoError(t, cl.SetParams(map[string]string{"<param>": "anotherValue"}))
+				st, err := cl.CurrentState()
+				assert.NoError(t, err)
+				assert.NotNil(t, st)
+				assert.Zero(t, st.Index)
+				assert.Len(t, st.Params, 1)
+				assert.Equal(t, "value", st.Params["<param>"])
+			})
+			t.Run("TestParamStateIsMaintained", func(t *testing.T) {
+				t.Run("WithNextCommand", func(t *testing.T) {
+					assert.NoError(t, cl.NextCommand())
+					st, err := cl.CurrentState()
+					assert.NoError(t, err)
+					assert.NotNil(t, st)
+					assert.Equal(t, 1, st.Index)
+					assert.Equal(t, "idx_1", st.Command)
+					assert.Len(t, st.Params, 1)
+					assert.Equal(t, "value", st.Params["<param>"])
+				})
+				t.Run("WithMoreParamsAdded", func(t *testing.T) {
+					assert.NoError(t, cl.SetParams(map[string]string{"<param2>": "value2"}))
+					st, err := cl.CurrentState()
+					assert.NoError(t, err)
+					assert.NotNil(t, st)
+					assert.Equal(t, st.Index, 1)
+					assert.Len(t, st.Params, 2)
+					assert.Equal(t, "value", st.Params["<param>"])
+					assert.Equal(t, "value2", st.Params["<param2>"])
+				})
+			})
+		})
+
 	})
 }
 

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -229,6 +229,7 @@ fi
 
 echo
 echo "Type 'exit' or press 'ctrl+d' to stop running."
+echo
 `
 
 func (z *zsh) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -17,3 +17,12 @@ func Has[T comparable](s []T, v T) bool {
 	return false
 }
 
+func Filter[T any](s []T, f func(T) bool) []T {
+	var result []T
+	for _, v := range s {
+		if f(v) {
+			result = append(result, v)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
- **server/run: Update default run socket name**
- **server/run: maintain state for set/unset params**
- **slice: support filtering**
- **Add support for setting params**
- **move extractParam to its own pkg**
- **server/run: Add CommandWithSetParams**
- **server/run: replace params with their values**
- **param: dedupe multiple instances of a single param**
- **stop using st.Command**
- **set-param: fix title**
- **set-param: use dracula**
- **shell/zsh: add newline after run setup msg**
- **set-param: add command title to share context of the parameter**
- **bash: add support for setting parameters**
- **cmd/set-param: fix spelling**
