### PR TITLE
next/prev: allow users to skip/retry commands  while executing runbooks

### DIFF
--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -29,17 +29,16 @@ var nextCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if state.CommandWithSetParams() != executedCommand {
-			fmt.Printf("%d", state.Index)
+		if forceNext || state.CommandWithSetParams() == executedCommand {
+			updated, err := nextCommand(ctx, cl)
+			if err != nil {
+				display.ErrorWithSupportCTA(err)
+				os.Exit(1)
+			}
+			fmt.Printf("%d", updated.Index)
 			return
 		}
-
-		updated, err := nextCommand(ctx, cl)
-		if err != nil {
-			display.ErrorWithSupportCTA(err)
-			os.Exit(1)
-		}
-		fmt.Printf("%d", updated.Index)
+		fmt.Printf("%d", state.Index)
 	},
 }
 
@@ -56,9 +55,12 @@ func nextCommand(ctx context.Context, cl run.Client) (*run.State, error) {
 }
 
 var executedCommand string
+var forceNext bool
 
 func init() {
 	InternalCmd.AddCommand(nextCmd)
 
 	nextCmd.Flags().StringVarP(&executedCommand, "cmd", "c", "", "previously executed command")
+	nextCmd.Flags().BoolVarP(&forceNext, "force", "f", false, "force next command regardless of current state")
+
 }

--- a/cmd/internal/next.go
+++ b/cmd/internal/next.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -33,18 +34,25 @@ var nextCmd = &cobra.Command{
 			return
 		}
 
-		if err := cl.NextCommand(); err != nil {
-			display.ErrorWithSupportCTA(err)
-			os.Exit(1)
-		}
-
-		updated, err := cl.CurrentState()
+		updated, err := nextCommand(ctx, cl)
 		if err != nil {
 			display.ErrorWithSupportCTA(err)
 			os.Exit(1)
 		}
 		fmt.Printf("%d", updated.Index)
 	},
+}
+
+func nextCommand(ctx context.Context, cl run.Client) (*run.State, error) {
+	if err := cl.NextCommand(); err != nil {
+		return nil, err
+	}
+
+	updatedState, err := cl.CurrentState()
+	if err != nil {
+		return nil, err
+	}
+	return updatedState, nil
 }
 
 var executedCommand string

--- a/cmd/internal/previous.go
+++ b/cmd/internal/previous.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/server/run"
+	"github.com/spf13/cobra"
+)
+
+// previousCommand represents the next command
+var previousCmd = &cobra.Command{
+	Use:    "previous",
+	Hidden: true,
+	Short:  "Update runbook state to the previous step",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		cl, err := run.NewDefaultClient(ctx)
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			return
+		}
+
+		state, err := cl.CurrentState()
+		if err != nil {
+			display.ErrorWithSupportCTA(err)
+			os.Exit(1)
+		}
+
+		if forcePrevious {
+			updated, err := previousCommand(ctx, cl)
+			if err != nil {
+				display.ErrorWithSupportCTA(err)
+				os.Exit(1)
+			}
+			fmt.Printf("%d", updated.Index)
+			return
+		}
+		fmt.Printf("%d", state.Index)
+	},
+}
+
+func previousCommand(ctx context.Context, cl run.Client) (*run.State, error) {
+	if err := cl.PreviousCommand(); err != nil {
+		return nil, err
+	}
+
+	updatedState, err := cl.CurrentState()
+	if err != nil {
+		return nil, err
+	}
+	return updatedState, nil
+}
+
+var forcePrevious bool
+
+func init() {
+	InternalCmd.AddCommand(previousCmd)
+	previousCmd.Flags().BoolVarP(&forcePrevious, "force", "f", false, "force previous command regardless of current state")
+}

--- a/server/run/run.go
+++ b/server/run/run.go
@@ -182,6 +182,11 @@ func (rs *RunServer) handleCommand(runCommand RunCommand, c net.Conn) {
 		if rs.currIndex > len(rs.commands) {
 			rs.currIndex = len(rs.commands)
 		}
+	case previousCommand:
+		rs.currIndex -= 1
+		if rs.currIndex < 0 {
+			rs.currIndex = 0
+		}
 	case currentCommand:
 		response := State{
 			Index:  rs.currIndex,

--- a/server/run/run_test.go
+++ b/server/run/run_test.go
@@ -63,6 +63,14 @@ func TestRunServer(t *testing.T) {
 		assert.NotNil(t, st)
 		assert.Equal(t, 1, st.Index)
 		assert.Equal(t, "idx_1", st.CommandWithSetParams())
+		t.Run("TestPreviousCommand", func(t *testing.T) {
+			assert.NoError(t, cl.PreviousCommand())
+			st, err := cl.CurrentState()
+			assert.NoError(t, err)
+			assert.NotNil(t, st)
+			assert.Equal(t, 0, st.Index)
+			assert.Equal(t, "idx_0", st.CommandWithSetParams())
+		})
 	})
 	t.Run("TestParam", func(t *testing.T) {
 		_, cl, cleanup := newTestServerWithClient(t, rb)


### PR DESCRIPTION
- **cmd/internal/next: Add nextCommand func**
- **cmd/internal/next: add --force flag**
- **server/run: Impl previous command.**
- **cmd/internal/previous: allow users to go back when executing runbooks**
