### PR TITLE
savvy ask: pass in historical commands as context

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -309,6 +309,7 @@ type QuestionInfo struct {
 	FileData          []byte            `json:"file_data,omitempty"`
 	FileName          string            `json:"file_name,omitempty"`
 	PreviousQuestions []string          `json:"previous_questions,omitempty"`
+	PreviousCommands  []string          `json:"previous_commands,omitempty"`
 }
 
 func (c *client) Ask(ctx context.Context, question QuestionInfo) (*Runbook, error) {

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -356,5 +356,5 @@ var useHistory bool
 func init() {
 	rootCmd.AddCommand(askCmd)
 	askCmd.Flags().StringVarP(&filePath, "file", "f", "", "File path for ask to read and use while generating an answer")
-	askCmd.Flags().BoolVarP(&useHistory, "history", "h", false, "Provide historical context to Savvy's AI model")
+	askCmd.Flags().BoolVarP(&useHistory, "history", "", false, "Provide historical context to Savvy's AI model")
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -224,7 +224,6 @@ func selectAndExpandHistory(ctx context.Context, logger *slog.Logger) ([]*server
 		ss.ListenAndServe()
 		// kill b/g shell if we exit early
 		cancelCtx()
-		os.Exit(1)
 	}()
 
 	if err != nil {


### PR DESCRIPTION
- **cmd/history: add selectAndExpandHistory func for future reuse**
- **fixup! cmd/history: add selectAndExpandHistory func for future reuse**
- **cmd/ask: allow users to attach historical context to their questions.**
- **cmd/ask: remove short hand flag for --history**
