### PR TITLE
Add fish support

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -41,7 +41,7 @@ func init() {
 
 func recordHistory(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
-	logger := loggerFromCtx(ctx).With("command", "history")
+	logger := loggerFromCtx(ctx).With("cmd", "history")
 
 	cl, err := client.GetLoggedInClient()
 	if err != nil && errors.Is(err, client.ErrInvalidClient) {
@@ -175,6 +175,7 @@ func expandHistory(ctx context.Context,
 
 	for i, cmd := range rawCommands {
 		if _, err := fmt.Fprintln(ptmx, cmd); err != nil {
+			logger.Debug("failed to write command to psuedo terminal", "error", err.Error())
 			return nil, err
 		}
 		// Wait for the command to be processed by the server.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,4 +26,5 @@ func init() {
 	initCmd.AddCommand(setup.ZshCmd)
 	initCmd.AddCommand(setup.BashCmd)
 	initCmd.AddCommand(setup.DashCmd)
+	initCmd.AddCommand(setup.FishCmd)
 }

--- a/cmd/setup/fish.go
+++ b/cmd/setup/fish.go
@@ -1,0 +1,28 @@
+package setup
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed savvy.fish
+var fishSetupFiles embed.FS
+
+const fishSetupScriptName = "savvy.fish"
+
+// fishCmd represents the fish command
+var FishCmd = &cobra.Command{
+	Use:   "fish",
+	Short: "Output shell setup for fish",
+	Long:  `Output shell setup for bash`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		content, err := fishSetupFiles.ReadFile(fishSetupScriptName)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(content))
+		return nil
+	},
+}

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -28,14 +28,7 @@ function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
         else
           echo -n $original_prompt
         end
-
-    if test "$SAVVY_CONTEXT" = "record" 
-      and test "$exit_code" -ne 0
-
-        set -x SAVVY_SOCKET_PATH $SAVVY_INPUT_FILE
-        savvy send --step-id="$step_id" --exit-code="$exit_code"
     end
-  end
 end
 
 
@@ -44,6 +37,22 @@ end
 # Call the function to set up the modified prompt
 __savvy_modify_prompt
 
+
+
+function __savvy_record_post_exec --on-event fish_postexec
+    set -l exit_code $status
+
+    if not test "$SAVVY_CONTEXT" = "record"
+        return
+    end
+
+    # Send the return code to the server if it's not 0
+    if test "$SAVVY_CONTEXT" = "record"
+      and test "$exit_code" -ne 0
+        set -x SAVVY_SOCKET_PATH $SAVVY_INPUT_FILE
+        savvy send --step-id="$step_id" --exit-code="$status"
+    end
+end
 
 
 

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -1,4 +1,4 @@
-SAVVY_INPUT_FILE=/tmp/savvy-socket
+set SAVVY_INPUT_FILE /tmp/savvy-socket
 
 
 # Fish automatically loads completions, so no need for 'autoload' or 'compinit'
@@ -6,7 +6,7 @@ SAVVY_INPUT_FILE=/tmp/savvy-socket
 # Load savvy completions
 savvy completion fish | source
 
-step_id=""
+set step_id ""
 
 
 function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
@@ -27,14 +27,14 @@ function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
         else
           echo -n $original_prompt
         end
-    end
 
     if test "$SAVVY_CONTEXT" = "record" 
-        and test "$exit_code" -ne 0
-        
+      and test "$exit_code" -ne 0
+
         set -x SAVVY_SOCKET_PATH $SAVVY_INPUT_FILE
         savvy send --step-id="$step_id" --exit-code="$exit_code"
     end
+  end
 end
 
 
@@ -58,7 +58,7 @@ function __savvy_record_pre_exec__ --on-event fish_preexec
         set -l prompt (fish_prompt)
         
         # Remove color codes and other formatting from the prompt
-        set -l clean_prompt (string replace -ra '\e\[[^m]*m' '' $prompt)
+        set -l clean_prompt (string replace -ra '\e\[[^m]*m' "" -- $prompt)
         
         # Send command to savvy and get step_id
         set -g step_id (

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -24,7 +24,7 @@ function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
         if test "$SAVVY_CONTEXT" = "record" 
           and not string match -q '*recording*' "$fish_prompt"
           echo -n $original_prompt
-          echo -n (set_color red)"recording"(set_color normal)" 😎 "
+          echo -n (set_color green)"recording"(set_color normal)" 😎 "
         else
           echo -n $original_prompt
         end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -1,0 +1,69 @@
+SAVVY_INPUT_FILE=/tmp/savvy-socket
+
+
+# Fish automatically loads completions, so no need for 'autoload' or 'compinit'
+
+# Load savvy completions
+savvy completion fish | source
+
+step_id=""
+
+
+function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
+    # Save the original prompt function if not already saved
+    if not functions -q __original_fish_prompt
+        functions -c fish_prompt __original_fish_prompt
+    end
+
+    # Define new fish_prompt function
+    function fish_prompt
+        # Call the original prompt function
+        set -l original_prompt (__original_fish_prompt)
+        set -l exit_code $status
+        if test "$SAVVY_CONTEXT" = "record" 
+          and not string match -q '*recording*' "$fish_prompt"
+          echo -n $original_prompt
+          echo -n (set_color red)"recording"(set_color normal)" 😎 "
+        else
+          echo -n $original_prompt
+        end
+    end
+
+    if test "$SAVVY_CONTEXT" = "record" 
+        and test "$exit_code" -ne 0
+        
+        set -x SAVVY_SOCKET_PATH $SAVVY_INPUT_FILE
+        savvy send --step-id="$step_id" --exit-code="$exit_code"
+    end
+end
+
+
+
+ 
+# Call the function to set up the modified prompt
+__savvy_modify_prompt
+
+
+
+
+function __savvy_record_pre_exec__ --on-event fish_preexec
+    # $argv[2] is the full command line in Fish
+    set -l cmd $argv[2]
+    
+    # Clear step_id
+    set -g step_id ""
+    
+    if test "$SAVVY_CONTEXT" = "record"
+        # Get the current prompt
+        set -l prompt (fish_prompt)
+        
+        # Remove color codes and other formatting from the prompt
+        set -l clean_prompt (string replace -ra '\e\[[^m]*m' '' $prompt)
+        
+        # Send command to savvy and get step_id
+        set -g step_id (
+            env SAVVY_SOCKET_PATH=$SAVVY_INPUT_FILE \
+            savvy send --prompt="$clean_prompt" $cmd
+        )
+    end
+end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -42,7 +42,9 @@ __savvy_record_prompt
 function __savvy_runbook_runner__ --on-event fish_prompt
     if test "$SAVVY_CONTEXT" = "run"
         set -l run_cmd (savvy internal current)
-        commandline -r $run_cmd
+        echo "run_cmd = $run_cmd"
+        fish_commandline_append "$run_cmd"
+        commandline -f repaint
     end
 end
 
@@ -56,7 +58,7 @@ set -g SAVVY_NEXT_STEP 0
 function __savvy_run_prompt --description "Modify prompt for Savvy run"
     # Save the original prompt function if not already saved
     if not functions -q __pre_savvy_run_prompt
-        set -g SAVVY_COMMANDS (string split ":COMMA:" $SAVVY_RUNBOOK_COMMANDS)
+        set -g SAVVY_COMMANDS (string split "COMMA" $SAVVY_RUNBOOK_COMMANDS)
         functions -c fish_prompt __pre_savvy_run_prompt
     end
 

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -43,7 +43,6 @@ function __savvy_runbook_runner__ --on-event fish_prompt
     if test "$SAVVY_CONTEXT" = "run"
         set -l run_cmd (savvy internal current)
         commandline -r $run_cmd
-        commandline -f end-of-line
     end
 end
 
@@ -80,7 +79,8 @@ function __savvy_run_prompt --description "Modify prompt for Savvy run"
 
         echo -n $original_prompt
         if test "$SAVVY_CONTEXT" = "run"
-          echo -n (set_color green)"savvy run $SAVVY_RUN_CURR"(set_color normal)
+          echo -n (set_color green)"savvy run" (set_color normal)
+          echo -n "$SAVVY_RUN_CURR"
         end
 
         if test "$SAVVY_CONTEXT" = "run"
@@ -97,7 +97,8 @@ function __savvy_run_prompt --description "Modify prompt for Savvy run"
           and test (count $SAVVY_COMMANDS) -gt 0
           and test "$SAVVY_NEXT_STEP" -lt (count $SAVVY_COMMANDS)
             set -l num (math $SAVVY_NEXT_STEP + 1)
-            echo -n (set_color green)"($num/(count $SAVVY_COMMANDS))"(set_color normal)
+            set -l count (count $SAVVY_COMMANDS)
+            echo -n (set_color green)"($num/$count)" (set_color normal)
         end
         echo -n $original_right_prompt
     end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -39,16 +39,6 @@ __savvy_record_prompt
 
 
 
-function __savvy_runbook_runner__ --on-event fish_prompt
-    if test "$SAVVY_CONTEXT" = "run"
-        set -l run_cmd (savvy internal current)
-        echo "run_cmd = $run_cmd"
-        fish_commandline_append "$run_cmd"
-        commandline -f repaint
-    end
-end
-
-
 # Initialize variables
 set -g SAVVY_COMMANDS ()
 set -g SAVVY_RUN_CURR ""
@@ -152,3 +142,23 @@ function __savvy_record_pre_exec__ --on-event fish_preexec
         )
     end
 end
+
+
+# Trigger completion on empty command line
+# Refer to shell/fish.go for triggering completion
+function __savvy_run_completion__ --description "Complete the current command in a runbook"
+    if not test "$SAVVY_CONTEXT" = "run"
+        return
+    end
+
+    set -l run_cmd (savvy internal current)
+    echo $cmd
+    set -l cmd (commandline -o)
+
+    if test -z "$cmd"
+        # Completions for empty command line
+        echo $run_cmd
+        return
+    end
+end
+

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -61,6 +61,13 @@ function __savvy_run_prompt --description "Modify prompt for Savvy run"
         functions -c fish_prompt __pre_savvy_run_prompt
     end
 
+    if not functions -q fish_right_prompt
+    # If fish_right_prompt doesn't exist, create an empty one
+      function fish_right_prompt
+        # Empty function
+      end
+    end
+
     if not functions -q __pre_savvy_run_right_prompt
       functions -c fish_right_prompt __pre_savvy_run_right_prompt
     end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -44,6 +44,17 @@ set -g SAVVY_COMMANDS ()
 set -g SAVVY_RUN_CURR ""
 set -g SAVVY_NEXT_STEP 0
 
+function __savvy_run_pre_exec --on-event fish_preexec
+    if not test "$SAVVY_CONTEXT" = "run"
+        return
+    end
+
+    set -l cmd $argv[1]
+
+    if test "$SAVVY_CONTEXT" = "run"
+        set -g SAVVY_NEXT_STEP (savvy internal next --cmd="$cmd")
+    end
+end
 
 function __savvy_run_prompt --description "Modify prompt for Savvy run"
     # Save the original prompt function if not already saved
@@ -144,20 +155,36 @@ function __savvy_record_pre_exec__ --on-event fish_preexec
 end
 
 
-# Trigger completion on empty command line
-# Refer to shell/fish.go for triggering completion
-function __savvy_run_completion__ --description "Complete the current command in a runbook"
+function __savvy_run_completion__ --on-event fish_prompt
     if not test "$SAVVY_CONTEXT" = "run"
         return
     end
 
     set -l run_cmd (savvy internal current)
-    echo $cmd
     set -l cmd (commandline -o)
 
     if test -z "$cmd"
         # Completions for empty command line
-        echo $run_cmd
+        commandline -i $run_cmd
+        return
+    end
+end
+
+
+
+# Trigger completion on empty command line
+# Refer to shell/fish.go for triggering completion
+function __savvy_run_completion_old__ --description "Complete the current command in a runbook"
+    if not test "$SAVVY_CONTEXT" = "run"
+        return
+    end
+
+    set -l run_cmd (savvy internal current)
+    set -l cmd (commandline -o)
+
+    if test -z "$cmd"
+        # Completions for empty command line
+        commandline -i $run_cmd
         return
     end
 end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -44,7 +44,7 @@ set -g SAVVY_COMMANDS ()
 set -g SAVVY_RUN_CURR ""
 set -g SAVVY_NEXT_STEP 0
 
-function __savvy_run_pre_exec --on-event fish_preexec
+function __savvy_run_pre_exec__ --on-event fish_preexec
     if not test "$SAVVY_CONTEXT" = "run"
         return
     end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -83,14 +83,15 @@ function __savvy_run_prompt --description "Modify prompt for Savvy run"
 
         echo -n $original_prompt
         if test "$SAVVY_CONTEXT" = "run"
-          echo -n (set_color --bold)"[ctrl-n: get next step]"(set_color normal)
-          echo -n (set_color green)"(savvy run" (set_color normal) "$SAVVY_RUN_CURR) "
+          and test "$SAVVY_NEXT_STEP" -lt (count $SAVVY_COMMANDS)
+            echo -n (set_color green)"(savvy run" (set_color normal) "$SAVVY_RUN_CURR) "(set_color normal)
+            echo -n (set_color --bold)"[ctrl-n: get next step]"(set_color normal)
         end
 
         if test "$SAVVY_CONTEXT" = "run"
           and test "$SAVVY_NEXT_STEP" -ge (count $SAVVY_COMMANDS)
             echo -n (set_color green)" done 😎"(set_color normal)
-            echo -n (set_color red)" ctrl-d/exit to exit"(set_color normal)
+            echo -n (set_color red)" type ctrl-d/exit to exit>  "(set_color normal)
         end
     end
 

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -6,7 +6,7 @@ set SAVVY_INPUT_FILE /tmp/savvy-socket
 # Load savvy completions
 savvy completion fish | source
 
-set step_id ""
+set -g step_id ""
 
 
 function __savvy_modify_prompt --description "Modify prompt for Savvy recording"

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -18,8 +18,9 @@ function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
     # Define new fish_prompt function
     function fish_prompt
         # Call the original prompt function
-        set -l original_prompt (__original_fish_prompt)
         set -l exit_code $status
+        set -l original_prompt (__original_fish_prompt)
+
         if test "$SAVVY_CONTEXT" = "record" 
           and not string match -q '*recording*' "$fish_prompt"
           echo -n $original_prompt
@@ -65,7 +66,7 @@ function __savvy_record_pre_exec__ --on-event fish_postexec
         #set -l clean_prompt (string replace -ra '\e\[[^m]*m' "" -- $prompt)
         
         # Send command to savvy and get step_id
-              #savvy send --prompt="$clean_prompt" $cmd
+        #savvy send --prompt="$clean_prompt" $cmd
         set -g step_id (
             env SAVVY_SOCKET_PATH=$SAVVY_INPUT_FILE \
             savvy send $cmd

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -9,17 +9,20 @@ savvy completion fish | source
 set -g step_id ""
 
 
-function __savvy_modify_prompt --description "Modify prompt for Savvy recording"
+# NOTE: If you change any function names, you must also change the corresponding check in shell/check_setup.go, shell/fish.go
+#
+# TODO: use templates to avoid the need to manually change shell checks
+
+function __savvy_record_prompt --description "Modify prompt for Savvy recording"
     # Save the original prompt function if not already saved
-    if not functions -q __original_fish_prompt
-        functions -c fish_prompt __original_fish_prompt
+    if not functions -q __pre_savvy_record_prompt
+        functions -c fish_prompt __pre_savvy_record_prompt
     end
 
     # Define new fish_prompt function
     function fish_prompt
         # Call the original prompt function
-        set -l exit_code $status
-        set -l original_prompt (__original_fish_prompt)
+        set -l original_prompt (__pre_savvy_record_prompt)
 
         if test "$SAVVY_CONTEXT" = "record" 
           and not string match -q '*recording*' "$fish_prompt"

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -97,7 +97,6 @@ function __savvy_run_prompt --description "Modify prompt for Savvy run"
           and test (count $SAVVY_COMMANDS) -gt 0
           and test "$SAVVY_NEXT_STEP" -lt (count $SAVVY_COMMANDS)
             set -l num (math $SAVVY_NEXT_STEP + 1)
-            echo -n $original_right_prompt
             echo -n (set_color green)"($num/(count $SAVVY_COMMANDS))"(set_color normal)
         end
         echo -n $original_right_prompt

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -47,7 +47,7 @@ __savvy_modify_prompt
 
 
 
-function __savvy_record_pre_exec__ --on-event fish_postexec
+function __savvy_record_pre_exec__ --on-event fish_preexec
     if not test "$SAVVY_CONTEXT" = "record"
         return
     end

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -34,12 +34,70 @@ function __savvy_record_prompt --description "Modify prompt for Savvy recording"
     end
 end
 
-
-
- 
 # Call the function to set up the modified prompt
-__savvy_modify_prompt
+__savvy_record_prompt
 
+
+
+function __savvy_runbook_runner__ --on-event fish_prompt
+    if test "$SAVVY_CONTEXT" = "run"
+        set -l run_cmd (savvy internal current)
+        commandline -r $run_cmd
+        commandline -f end-of-line
+    end
+end
+
+
+# Initialize variables
+set -g SAVVY_COMMANDS ()
+set -g SAVVY_RUN_CURR ""
+set -g SAVVY_NEXT_STEP 0
+
+
+function __savvy_run_prompt --description "Modify prompt for Savvy run"
+    # Save the original prompt function if not already saved
+    if not functions -q __pre_savvy_run_prompt
+        set -g SAVVY_COMMANDS (string split ":COMMA:" $SAVVY_RUNBOOK_COMMANDS)
+        functions -c fish_prompt __pre_savvy_run_prompt
+    end
+
+    if not functions -q __pre_savvy_run_right_prompt
+      functions -c fish_right_prompt __pre_savvy_run_right_prompt
+    end
+
+    # Define new fish_prompt function
+    function fish_prompt
+        # Call the original prompt function
+        set -l original_prompt (__pre_savvy_run_prompt)
+        set -g SAVVY_RUN_CURR "$SAVVY_RUNBOOK_ALIAS"
+
+        echo -n $original_prompt
+        if test "$SAVVY_CONTEXT" = "run"
+          echo -n (set_color green)"savvy run $SAVVY_RUN_CURR"(set_color normal)
+        end
+
+        if test "$SAVVY_CONTEXT" = "run"
+          and test "$SAVVY_NEXT_STEP" -ge (count $SAVVY_COMMANDS)
+            echo -n (set_color green)" done 😎"(set_color normal)
+            echo -n (set_color red)" ctrl-d/exit to exit"(set_color normal)
+        end
+    end
+
+    function fish_right_prompt
+        set -l original_right_prompt (__pre_savvy_run_right_prompt)
+
+        if test "$SAVVY_CONTEXT" = "run"
+          and test (count $SAVVY_COMMANDS) -gt 0
+          and test "$SAVVY_NEXT_STEP" -lt (count $SAVVY_COMMANDS)
+            set -l num (math $SAVVY_NEXT_STEP + 1)
+            echo -n $original_right_prompt
+            echo -n (set_color green)"($num/(count $SAVVY_COMMANDS))"(set_color normal)
+        end
+        echo -n $original_right_prompt
+    end
+end
+
+__savvy_run_prompt
 
 
 function __savvy_record_post_exec --on-event fish_postexec
@@ -69,14 +127,14 @@ function __savvy_record_pre_exec__ --on-event fish_preexec
 
     # Clear step_id
     set -g step_id ""
-    
+
     if test "$SAVVY_CONTEXT" = "record"
         # Get the current prompt
         #set -l prompt (fish_prompt)
-        
+
         # Remove color codes and other formatting from the prompt
         #set -l clean_prompt (string replace -ra '\e\[[^m]*m' "" -- $prompt)
-        
+
         # Send command to savvy and get step_id
         #savvy send --prompt="$clean_prompt" $cmd
         set -g step_id (

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -24,7 +24,7 @@ function __savvy_record_prompt --description "Modify prompt for Savvy recording"
         # Call the original prompt function
         set -l original_prompt (__pre_savvy_record_prompt)
 
-        if test "$SAVVY_CONTEXT" = "record" 
+        if test "$SAVVY_CONTEXT" = "record"
           and not string match -q '*recording*' "$fish_prompt"
           echo -n $original_prompt
           echo -n (set_color green)"recording"(set_color normal)" 😎 "

--- a/cmd/setup/savvy.fish
+++ b/cmd/setup/savvy.fish
@@ -46,24 +46,29 @@ __savvy_modify_prompt
 
 
 
-function __savvy_record_pre_exec__ --on-event fish_preexec
+function __savvy_record_pre_exec__ --on-event fish_postexec
+    if not test "$SAVVY_CONTEXT" = "record"
+        return
+    end
+
     # $argv[2] is the full command line in Fish
-    set -l cmd $argv[2]
-    
+    set -l cmd $argv[1]
+
     # Clear step_id
     set -g step_id ""
     
     if test "$SAVVY_CONTEXT" = "record"
         # Get the current prompt
-        set -l prompt (fish_prompt)
+        #set -l prompt (fish_prompt)
         
         # Remove color codes and other formatting from the prompt
-        set -l clean_prompt (string replace -ra '\e\[[^m]*m' "" -- $prompt)
+        #set -l clean_prompt (string replace -ra '\e\[[^m]*m' "" -- $prompt)
         
         # Send command to savvy and get step_id
+              #savvy send --prompt="$clean_prompt" $cmd
         set -g step_id (
             env SAVVY_SOCKET_PATH=$SAVVY_INPUT_FILE \
-            savvy send --prompt="$clean_prompt" $cmd
+            savvy send $cmd
         )
     end
 end

--- a/install/install.sh
+++ b/install/install.sh
@@ -66,12 +66,14 @@ case :$PATH:
      *) case :$shell:
        in *zsh*) echo "${BLUE}${BOLD} echo 'export PATH=\"$bin_dir:\$PATH\"' >> ~/.zshrc${RESET}";;
           *bash*) echo "${BLUE}${BOLD} echo 'export PATH=\"$bin_dir:\$PATH\"' >> ~/.bashrc${RESET}";;
+          *fish*) echo "${BLUE}${BOLD} echo 'fish_add_path -P $bin_dir' >> ~/.config/fish/config.fish${RESET}";;
      esac;;
 esac
 
 case :$shell:
   in  *zsh*) echo "${BLUE}${BOLD} echo 'eval \"\$(savvy init zsh)\"' >> ~/.zshrc${RESET}";;
       *bash*) echo "${BLUE}${BOLD} echo 'eval \"\$(savvy init bash)\"' >> ~/.bashrc${RESET}";;
+      *fish*) echo "${BLUE}${BOLD} echo 'savvy init fish | source' >> ~/.config/fish/config.fish${RESET}";;
 esac
 
 
@@ -94,10 +96,10 @@ fi
 case :$shell:
   in  *zsh*) echo "${BLUE}${BOLD} source ~/.zshrc # to pick up the new changes${RESET}";;
       *bash*) echo "${BLUE}${BOLD} source ~/.bashrc # to pick up the new changes${RESET}";;
+      *fish*) echo "${BLUE}${BOLD} source ~/.config/fish/config.fish # to pick up the new changes${RESET}";;
 esac
 
 echo
 echo "Run 'savvy help' to learn more or checkout our docs at https://github.com/getsavvyinc/savvy-cli"
 echo
-echo "${RED}${BOLD}Stuck? We'd love to help. Just join our Discord https://getsavvy.so/discord${RESET}"
-
+echo "${GREEN}${BOLD}Join Savvy's Discord https://getsavvy.so/discord if you have questions or feedback${RESET}"

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -47,14 +47,14 @@ set -g SAVVY_INPUT_FILE {{.SocketPath}}
 
 `
 
+// fishRecordHistoryScript is a fish script that records the command history.
+// The redirect to > /dev/null is important. Without it, savvy send is not executed
 const fishRecordHistoryScript = `
-
 function savvy_record_history_skip_execution --on-event fish_preexec
   set -l cmd $argv[1]
-  SAVVY_SOCKET_PATH={{.SocketPath}} savvy send "$cmd"
+  SAVVY_SOCKET_PATH=$SAVVY_INPUT_FILE savvy send $cmd > /dev/null
   exec fish
 end
-
 `
 
 var (
@@ -167,7 +167,7 @@ func (f *fish) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 	dataDirs := addVendorDirToXDGDataDirPath(vendorDir)
 
 	cmd := exec.CommandContext(ctx, f.shellCmd)
-	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=history", fmt.Sprintf("XDG_DATA_DIRS=%s", dataDirs))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("XDG_DATA_DIRS=%s", dataDirs))
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd, nil
 }

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -38,7 +38,18 @@ end
 set -g SAVVY_INPUT_FILE {{.SocketPath}}
 `
 
-var fishTemplate *template.Template
+const fishRecordHistoryScript = `
+function savvy_record_history_skip_execution --on-event fish_preexec
+  set -l cmd $argv[1]
+  SAVVY_SOCKET_PATH={{.SocketPath}} savvy send "$cmd"
+  exec fish
+end
+`
+
+var (
+	fishTemplate              *template.Template
+	fishRecordHistoryTemplate *template.Template
+)
 
 func init() {
 	fishTemplate = template.Must(template.New("fish").Parse(fishBaseScript))

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -114,6 +114,7 @@ func (f *fish) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 
 const fishRunRunbookScript = `
 if not functions -q __savvy_run_pre_exec__
+   or not functions -q __savvy_run_completion__
     set_color red
     echo " Your shell is not configured to use Savvy. Please run the following commands: "
     set_color normal
@@ -124,6 +125,8 @@ if not functions -q __savvy_run_pre_exec__
     set_color normal
     exit 1
 end
+
+complete -c '' -f -a "(__savvy_run_completion__)"
 
 echo
 echo "Type 'exit' or press 'ctrl+d' to stop running."

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -126,7 +126,7 @@ if not functions -q __savvy_run_pre_exec__
     exit 1
 end
 
-complete -c '' -f -a "(__savvy_run_completion__)"
+bind \cn '__savvy_run_completion__ "__savvy_run_completion__"'
 
 echo
 echo "Type 'exit' or press 'ctrl+d' to stop running."

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -37,22 +37,22 @@ end
 
 set -g SAVVY_INPUT_FILE {{.SocketPath}}
 
-# Fish doesn't use the same startup files as Bash, but we can approximate the behavior
-if status is-login
-    if test -f "/etc/fish/config.fish"
-        source "/etc/fish/config.fish"
-    end
-    if test -f "$HOME/.config/fish/config.fish"
-        source "$HOME/.config/fish/config.fish"
-    end
-else
-    if test -f "/etc/fish/conf.d/login.fish"
-        source "/etc/fish/conf.d/login.fish"
-    end
-    if test -f "$HOME/.config/fish/conf.d/login.fish"
-        source "$HOME/.config/fish/conf.d/login.fish"
-    end
-end
+## Fish doesn't use the same startup files as Bash, but we can approximate the behavior
+#if status is-login
+#    if test -f "/etc/fish/config.fish"
+#        source "/etc/fish/config.fish"
+#    end
+#    if test -f "$HOME/.config/fish/config.fish"
+#        source "$HOME/.config/fish/config.fish"
+#    end
+#else
+#    if test -f "/etc/fish/conf.d/login.fish"
+#        source "/etc/fish/conf.d/login.fish"
+#    end
+#    if test -f "$HOME/.config/fish/conf.d/login.fish"
+#        source "$HOME/.config/fish/conf.d/login.fish"
+#    end
+#end
 `
 const fishRecordSetup = `
 if not functions -q __savvy_record_pre_exec__
@@ -124,8 +124,8 @@ if not functions -q __savvy_run_pre_exec__
     set_color normal
     set_color red
     echo
-    echo -n "> echo 'savvy init fish | source' >> ~/.config/fish/config.fish"
-    echo -n "> source ~/.config/fish/config.fish"
+    echo "> echo 'savvy init fish | source' >> ~/.config/fish/config.fish"
+    echo "> source ~/.config/fish/config.fish"
     set_color normal
     exit 1
 end

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -25,17 +25,22 @@ type fish struct {
 }
 
 const fishBaseScript = `
-switch "$OSTYPE"
-    case 'solaris*'
-    case 'darwin*'
-    case 'linux*'
-    case 'bsd*'
-    case 'msys*'
-        echo "windows os is not supported"
-    case 'cygwin*'
-        echo "windows os is not supported"
+# Get the operating system name
+set os (uname -s)
+
+switch $os
+    case Darwin
+        echo "macOS detected"
+    case Linux
+        echo "Linux detected"
+    case 'CYGWIN*' 'MINGW*' 'MSYS*'
+        echo "Windows OS is not supported"
+    case FreeBSD NetBSD DragonFly
+        echo "BSD detected"
+    case SunOS
+        echo "Solaris detected"
     case '*'
-        echo "unknown: $OSTYPE"
+        echo "Unknown OS: $os"
 end
 
 set -g SAVVY_INPUT_FILE {{.SocketPath}}

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -25,24 +25,6 @@ type fish struct {
 }
 
 const fishBaseScript = `
-# Get the operating system name
-set os (uname -s)
-
-switch $os
-    case Darwin
-        echo "macOS detected"
-    case Linux
-        echo "Linux detected"
-    case 'CYGWIN*' 'MINGW*' 'MSYS*'
-        echo "Windows OS is not supported"
-    case FreeBSD NetBSD DragonFly
-        echo "BSD detected"
-    case SunOS
-        echo "Solaris detected"
-    case '*'
-        echo "Unknown OS: $os"
-end
-
 set -g SAVVY_INPUT_FILE {{.SocketPath}}
 
 `

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -22,9 +22,6 @@ type fish struct {
 }
 
 const fishBaseScript = `
-set RED (tput setaf 1)
-set RESET (tput sgr0)
-
 switch "$OSTYPE"
     case 'solaris*'
     case 'darwin*'
@@ -38,7 +35,7 @@ switch "$OSTYPE"
         echo "unknown: $OSTYPE"
 end
 
-set SAVVY_INPUT_FILE {{.SocketPath}}
+set -g SAVVY_INPUT_FILE {{.SocketPath}}
 
 # Fish doesn't use the same startup files as Bash, but we can approximate the behavior
 if status is-login
@@ -57,11 +54,11 @@ else
     end
 end
 
-if not functions -q savvy_cmd_pre_exec
-    echo "$RED Your shell is not configured to use Savvy. Please run the following commands: $RESET"
+if not functions -q __savvy_record_pre_exec__
+    echo (set_color red) "Your shell is not configured to use Savvy. Please run the following commands: " (set_color normal)
     echo
-    echo "$RED> echo 'eval (savvy init fish)' >> ~/.config/fish/config.fish$RESET"
-    echo "$RED> source ~/.config/fish/config.fish$RESET"
+    echo (set_color red)"> echo 'savvy init fish | source' >> ~/.config/fish/config.fish"(set_color normal)
+    echo (set_color red)"> source ~/.config/fish/config.fish"(set_color normal)
     exit 1
 end
 `

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -74,6 +74,7 @@ var fishTemplate, fishHistoryTemplate, fishRunTemplate *template.Template
 
 func init() {
 	fishTemplate = template.Must(template.New("fish").Parse(fishBaseScript + fishRecordSetup))
+	fishRunTemplate = template.Must(template.New("fishRun").Parse(fishBaseScript + fishRunRunbookScript))
 }
 
 // Spawn starts a fish shell.
@@ -114,8 +115,51 @@ func (f *fish) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 	return nil, nil
 }
 
+const fishRunRunbookScript = `
+if not functions -q __savvy_run_pre_exec__
+    set_color red
+    echo " Your shell is not configured to use Savvy. Please run the following commands: "
+    set_color normal
+    echo
+    set_color red
+    echo "> echo 'savvy init fish | source' >> ~/.config/fish/config.fish"
+    echo "> source ~/.config/fish/config.fish"
+    set_color normal
+    exit 1
+end
+
+echo
+echo "Type 'exit' or press 'ctrl+d' to stop running."
+echo
+`
+
 func (f *fish) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
-	return nil, nil
+	tmpDir := os.TempDir()
+	fishVendorConfDir := filepath.Join(tmpDir, "fish", "vendor_conf.d")
+	if err := os.MkdirAll(fishVendorConfDir, 0755); err != nil {
+		return nil, err
+	}
+	fishrc, err := os.CreateTemp(fishVendorConfDir, "savvy-fishrc-*.fish")
+	if err != nil {
+		return nil, err
+	}
+	defer fishrc.Close()
+
+	if err := fishRunTemplate.Execute(fishrc, f); err != nil {
+		return nil, err
+	}
+
+	dataDirs := os.Getenv("XDG_DATA_DIRS")
+	if dataDirs == "" {
+		dataDirs = fishVendorConfDir
+	} else {
+		dataDirs = strings.Join([]string{dataDirs, fishVendorConfDir}, ":")
+	}
+	cmd := exec.CommandContext(ctx, f.shellCmd)
+	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=run", fmt.Sprintf("XDG_DATA_DIRS=%s", dataDirs))
+	cmd.Env = append(cmd.Env, runbookRunMetadata(runbook, f)...)
+	cmd.WaitDelay = 500 * time.Millisecond
+	return cmd, nil
 }
 
 func (f *fish) DefaultStartingArrayIndex() int {

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -55,33 +55,48 @@ func init() {
 	fishTemplate = template.Must(template.New("fish").Parse(fishBaseScript))
 }
 
-// Spawn starts a fish shell.
-func (f *fish) Spawn(ctx context.Context) (*exec.Cmd, error) {
+// injectVendorCode injects the vendor code into the fish shell configuration.
+// It returns the parent directory that containsins the fish/vendor_conf.d directory.
+// This directory should be added to the XDG_DATA_DIRS environment variable.
+func (f *fish) injectVendorCode(vendorCode *template.Template) (string, error) {
 	// Create a temporary file to store the script
 	tmpDir, err := os.MkdirTemp("", "savvy-fish-*")
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	fishVendorConfDir := filepath.Join(tmpDir, "fish", "vendor_conf.d")
 	if err := os.MkdirAll(fishVendorConfDir, 0755); err != nil {
-		return nil, err
+		return "", err
 	}
 	fishrc, err := os.CreateTemp(fishVendorConfDir, "savvy-fishrc-*.fish")
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer fishrc.Close()
 
-	if err := fishTemplate.Execute(fishrc, f); err != nil {
+	if err := vendorCode.Execute(fishrc, f); err != nil {
+		return "", err
+	}
+	return tmpDir, nil
+}
+
+func addVendorDirToXDGDataDirPath(vendorDir string) string {
+	if dataDirs := os.Getenv("XDG_DATA_DIRS"); len(dataDirs) > 0 {
+		return strings.Join([]string{dataDirs, vendorDir}, ":")
+	}
+	return vendorDir
+}
+
+// Spawn starts a fish shell.
+func (f *fish) Spawn(ctx context.Context) (*exec.Cmd, error) {
+	// Create a temporary file to store the script
+	vendorDir, err := f.injectVendorCode(fishTemplate)
+	if err != nil {
 		return nil, err
 	}
 
-	dataDirs := os.Getenv("XDG_DATA_DIRS")
-	if dataDirs == "" {
-		dataDirs = tmpDir
-	} else {
-		dataDirs = strings.Join([]string{dataDirs, tmpDir}, ":")
-	}
+	dataDirs := addVendorDirToXDGDataDirPath(vendorDir)
+
 	cmd := exec.CommandContext(ctx, f.shellCmd)
 	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=record", fmt.Sprintf("XDG_DATA_DIRS=%s", dataDirs))
 	cmd.WaitDelay = 500 * time.Millisecond
@@ -97,30 +112,12 @@ func (f *fish) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
 }
 
 func (f *fish) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
-	tmpDir, err := os.MkdirTemp("", "savvy-fish-*")
+	vendorDir, err := f.injectVendorCode(fishTemplate)
 	if err != nil {
 		return nil, err
 	}
-	fishVendorConfDir := filepath.Join(tmpDir, "fish", "vendor_conf.d")
-	if err := os.MkdirAll(fishVendorConfDir, 0755); err != nil {
-		return nil, err
-	}
-	fishrc, err := os.CreateTemp(fishVendorConfDir, "savvy-fishrc-*.fish")
-	if err != nil {
-		return nil, err
-	}
-	defer fishrc.Close()
+	dataDirs := addVendorDirToXDGDataDirPath(vendorDir)
 
-	if err := fishTemplate.Execute(fishrc, f); err != nil {
-		return nil, err
-	}
-
-	dataDirs := os.Getenv("XDG_DATA_DIRS")
-	if dataDirs == "" {
-		dataDirs = tmpDir
-	} else {
-		dataDirs = strings.Join([]string{dataDirs, tmpDir}, ":")
-	}
 	cmd := exec.CommandContext(ctx, f.shellCmd)
 	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=run", fmt.Sprintf("XDG_DATA_DIRS=%s", dataDirs))
 	cmd.Env = append(cmd.Env, runbookRunMetadata(runbook, f)...)

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -1,0 +1,110 @@
+package shell
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"text/template"
+	"time"
+
+	"github.com/getsavvyinc/savvy-cli/client"
+)
+
+var _ Shell = (*fish)(nil)
+
+type fish struct {
+	shellCmd string
+	// Exported to use in template
+	SocketPath string
+}
+
+const fishBaseScript = `
+set RED (tput setaf 1)
+set RESET (tput sgr0)
+
+switch "$OSTYPE"
+    case 'solaris*'
+    case 'darwin*'
+    case 'linux*'
+    case 'bsd*'
+    case 'msys*'
+        echo "windows os is not supported"
+    case 'cygwin*'
+        echo "windows os is not supported"
+    case '*'
+        echo "unknown: $OSTYPE"
+end
+
+set SAVVY_INPUT_FILE {{.SocketPath}}
+
+# Fish doesn't use the same startup files as Bash, but we can approximate the behavior
+if status is-login
+    if test -f "/etc/fish/config.fish"
+        source "/etc/fish/config.fish"
+    end
+    if test -f "$HOME/.config/fish/config.fish"
+        source "$HOME/.config/fish/config.fish"
+    end
+else
+    if test -f "/etc/fish/conf.d/login.fish"
+        source "/etc/fish/conf.d/login.fish"
+    end
+    if test -f "$HOME/.config/fish/conf.d/login.fish"
+        source "$HOME/.config/fish/conf.d/login.fish"
+    end
+end
+
+if not functions -q savvy_cmd_pre_exec
+    echo "$RED Your shell is not configured to use Savvy. Please run the following commands: $RESET"
+    echo
+    echo "$RED> echo 'eval (savvy init fish)' >> ~/.config/fish/config.fish$RESET"
+    echo "$RED> source ~/.config/fish/config.fish$RESET"
+    exit 1
+end
+`
+const fishRecordSetup = `
+echo
+echo "Type 'exit' or press 'ctrl+d' to stop recording."
+`
+
+var fishTemplate, fishHistoryTemplate, fishRunTemplate *template.Template
+
+func init() {
+	fishTemplate = template.Must(template.New("fish").Parse(fishBaseScript + fishRecordSetup))
+}
+
+// Spawn starts a fish shell.
+func (f *fish) Spawn(ctx context.Context) (*exec.Cmd, error) {
+	// Create a temporary file to store the script
+	tmpDir := os.TempDir()
+	fishrc, err := os.CreateTemp(tmpDir, "savvy-fishrc-*.fish")
+	if err != nil {
+		return nil, err
+	}
+	defer fishrc.Close()
+
+	if err := fishTemplate.Execute(fishrc, f); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, f.shellCmd, "-C", fishrc.Name())
+	cmd.Env = append(os.Environ(), "SAVVY_CONTEXT=record")
+	cmd.WaitDelay = 500 * time.Millisecond
+	return cmd, nil
+}
+
+func (f *fish) TailHistory(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (f *fish) SpawnHistoryExpander(ctx context.Context) (*exec.Cmd, error) {
+	return nil, nil
+}
+
+func (f *fish) SpawnRunbookRunner(ctx context.Context, runbook *client.Runbook) (*exec.Cmd, error) {
+	return nil, nil
+}
+
+func (f *fish) DefaultStartingArrayIndex() int {
+	return 1
+}

--- a/shell/spawn.go
+++ b/shell/spawn.go
@@ -33,6 +33,12 @@ func New(logTarget string) Shell {
 			shellCmd:   "bash",
 			SocketPath: logTarget,
 		}
+
+	case kind.Fish:
+		return &fish{
+			shellCmd:   "fish",
+			SocketPath: logTarget,
+		}
 	default:
 		return &todo{}
 	}


### PR DESCRIPTION
- **shell: Impl Shell for fish**
- **cmd/setup: savvy.fish setup prompt and hooks for recording artifacts**
- **setup: impl fish setup**
- **setup/fish: use well known XDG_DATA_DIRS dir to configure fish shells**
- **cmd/setup/fish: setup script for recording commands.**
- **setup: get status code before copying prompt**
- **setup/fish: use green instead of red for recording**
- **setup/fish: record command as part of pre-exec hook**
- **setup/fish: use post_exec hook to capture exit code.**
- **setup/fish: make step_id global**
- **setup/fish: rename savvy_modify_prompt -> savvy_record_prompt**
- **setup/fish: rm trailing whitespace**
- **setup/fish: impl prompt and cli integration for savvy run**
- **setup/fish: handle case where fish_right_prompt dne**
- **display original prompt on the right at the end**
- **shell/fish: impl SpawnRunner**
- **rm commandline -f**
- **shell/fish: simplify setup script**
- **setup/fish: split on COMMA not :COMMA:**
- **shell/fish: use completion to suggest commands in savvy run**
- **setup/fish: savvy run completion hooks**
- **work out issues with vendor dirs and color sequences**
- **fish auto inlcudes its config files**
- **setup/fish: vendor code in fish is loaded before user configured**
- **shell/fish: add pre_exec function that records but does not execute a command**
- **shell/fish: DRY vendorDir and dataDirs setup**
- **shell/fish: impl record history**
- **shell/fish: replace OSTYPE with uname -s**
- **shell/fish: add pre_exec hook to record history without executing**
- **cmd/history: improve debugl logging**
