### PR TITLE
Export commands locally

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -285,6 +285,17 @@ func (dc *askCommands) Init() tea.Cmd {
 	return nil
 }
 
+func toItems(steps []component.RunbookStep) []list.Item {
+	var items []list.Item
+	for _, step := range steps {
+		items = append(items, list.Item{
+			Command:         step.Command,
+			DescriptionText: step.Description,
+		})
+	}
+	return items
+}
+
 func (dc *askCommands) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg.(type) {
 	case list.RefinePromptMsg:

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -16,7 +16,6 @@ import (
 	"github.com/charmbracelet/huh"
 	huhSpinner "github.com/charmbracelet/huh/spinner"
 	"github.com/creack/pty"
-	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/getsavvyinc/savvy-cli/export"
 	"github.com/getsavvyinc/savvy-cli/redact"
@@ -45,15 +44,6 @@ func recordHistory(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
 	logger := loggerFromCtx(ctx).With("cmd", "history")
 
-	cl, err := client.GetLoggedInClient()
-	if err != nil && errors.Is(err, client.ErrInvalidClient) {
-		display.Error(errors.New("You must be logged in to create an artifact. Please run `savvy login`"))
-		os.Exit(1)
-	} else if err != nil {
-		display.ErrorWithSupportCTA(err)
-		os.Exit(1)
-	}
-
 	historyCmds, err := selectAndExpandHistory(ctx, logger)
 	if err != nil {
 		display.FatalErrWithSupportCTA(err)
@@ -65,7 +55,7 @@ func recordHistory(cmd *cobra.Command, _ []string) {
 	}
 
 	exporter := export.NewExporter(historyCmds)
-	if err := exporter.ToSavvyArtifact(ctx, cl); err != nil {
+	if err := exporter.Export(ctx); err != nil {
 		display.ErrorWithSupportCTA(err)
 		os.Exit(1)
 	}

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 
 	"github.com/creack/pty"
-	"github.com/getsavvyinc/savvy-cli/client"
 	"github.com/getsavvyinc/savvy-cli/display"
 	"github.com/getsavvyinc/savvy-cli/export"
 	"github.com/getsavvyinc/savvy-cli/redact"
@@ -45,14 +44,6 @@ var recordCmd = &cobra.Command{
 var programOutput = termenv.NewOutput(os.Stdout, termenv.WithColorCache(true))
 
 func runRecordCmd(cmd *cobra.Command, _ []string) {
-	cl, err := client.GetLoggedInClient()
-	if err != nil && errors.Is(err, client.ErrInvalidClient) {
-		display.Error(errors.New("You must be logged in to record a runbook. Please run `savvy login`"))
-		os.Exit(1)
-	} else if err != nil {
-		display.ErrorWithSupportCTA(err)
-		os.Exit(1)
-	}
 	ctx := cmd.Context()
 
 	recordedCommands, err := startRecording(ctx)
@@ -78,7 +69,7 @@ func runRecordCmd(cmd *cobra.Command, _ []string) {
 	}
 
 	exporter := export.NewExporter(redactedCommands)
-	if err := exporter.ToSavvyArtifact(ctx, cl); err != nil {
+	if err := exporter.Export(ctx); err != nil {
 		display.ErrorWithSupportCTA(err)
 		os.Exit(1)
 	}

--- a/export/markdown/markdown.go
+++ b/export/markdown/markdown.go
@@ -1,0 +1,90 @@
+package markdown
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"text/template"
+	"time"
+
+	"github.com/atotto/clipboard"
+	"github.com/getsavvyinc/savvy-cli/display"
+)
+
+const MdTemplate = `I used [Savvy's CLI]({{ .URL }}) to record these commands:
+
+{{- printf "\n" -}}
+{{- range $i, $command := .Commands }}
+
+ ~~~sh
+ {{ add $i 1 }}. {{ $command }}
+ ~~~
+
+{{- printf "\n" -}}
+{{- end -}}
+`
+
+type Service interface {
+	ToMarkdownFile(ctx context.Context, commands []string) error
+}
+
+var mdTemplate *template.Template
+
+func init() {
+	mdTemplate = template.Must(template.New("md").Funcs(template.FuncMap{
+		"add": func(a, b int) int {
+			return a + b
+		}}).Parse(MdTemplate))
+}
+
+type svc struct {
+	url string
+}
+
+func NewService() Service {
+	return &svc{
+		url: "https://github.com/getsavvyinc/savvy-cli",
+	}
+}
+
+func (s *svc) ToMarkdownFile(ctx context.Context, commands []string) error {
+	data := struct {
+		Commands []string
+		URL      string
+	}{
+		URL:      s.url,
+		Commands: commands,
+	}
+
+	var buf bytes.Buffer
+	if err := mdTemplate.Execute(&buf, data); err != nil {
+		err = fmt.Errorf("error executing markdown template: %w", err)
+		return err
+	}
+
+	mdContent := buf.String()
+
+	defer func() {
+		if cerr := clipboard.WriteAll(mdContent); cerr != nil {
+			display.Info("Wrote md contents to clipboard")
+		}
+	}()
+
+	humanReadableTime := time.Now().Format("2006_01_02_15:04:05")
+	fileName := fmt.Sprintf("savvy_%s.md", humanReadableTime)
+	f, err := os.Create(fileName)
+	if err != nil {
+		err = fmt.Errorf("failed to create mardown file: %w", err)
+		return err
+	}
+
+	defer f.Close()
+	if _, err := f.WriteString(mdContent); err != nil {
+		err = fmt.Errorf("failed to write md to file: %w", err)
+		return err
+	}
+
+	display.Info(fmt.Sprintf("Markdown file created: %s", fileName))
+	return nil
+}

--- a/export/markdown/markdown.go
+++ b/export/markdown/markdown.go
@@ -67,8 +67,10 @@ func (s *svc) ToMarkdownFile(ctx context.Context, commands []string) error {
 
 	defer func() {
 		if cerr := clipboard.WriteAll(mdContent); cerr != nil {
-			display.Info("Wrote md contents to clipboard")
+			err := fmt.Errorf("failed to write md contents to clipboard: %w", cerr)
+			display.Error(err)
 		}
+		display.Info("Wrote md contents to clipboard")
 	}()
 
 	humanReadableTime := time.Now().Format("2006_01_02_15:04:05")

--- a/export/savvy.go
+++ b/export/savvy.go
@@ -12,7 +12,9 @@ import (
 	"github.com/getsavvyinc/savvy-cli/cmd/component"
 	"github.com/getsavvyinc/savvy-cli/cmd/component/list"
 	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/export/markdown"
 	"github.com/getsavvyinc/savvy-cli/server"
+	"github.com/getsavvyinc/savvy-cli/slice"
 	"github.com/muesli/termenv"
 )
 
@@ -34,7 +36,7 @@ func (e *exporter) Export(ctx context.Context) error {
 		Description("Select an export format").
 		Options(
 			huh.NewOption("Local Markdown File", MarkdownFile),
-			huh.NewOption("Savvy Artifact (Share with your team)", SavvyArtifact),
+			huh.NewOption("Savvy Artifact (Recommended)", SavvyArtifact),
 		).Value(&exportFormat).Run(); err != nil {
 		return err
 	}
@@ -53,15 +55,20 @@ func (e *exporter) Export(ctx context.Context) error {
 func NewExporter(commands []*server.RecordedCommand) Exporter {
 	return &exporter{
 		commands: commands,
+		mdSvc:    markdown.NewService(),
 	}
 }
 
 type exporter struct {
 	commands []*server.RecordedCommand
+	mdSvc    markdown.Service
 }
 
 func (e *exporter) toMarkdownFile(ctx context.Context) error {
-	panic("implement me")
+	commands := slice.Map(e.commands, func(rc *server.RecordedCommand) string {
+		return rc.Command
+	})
+	return e.mdSvc.ToMarkdownFile(ctx, commands)
 }
 
 func (e *exporter) toSavvyArtifact(ctx context.Context) error {

--- a/export/savvy.go
+++ b/export/savvy.go
@@ -1,0 +1,107 @@
+package export
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/getsavvyinc/savvy-cli/client"
+	"github.com/getsavvyinc/savvy-cli/cmd/component"
+	"github.com/getsavvyinc/savvy-cli/cmd/component/list"
+	"github.com/getsavvyinc/savvy-cli/display"
+	"github.com/getsavvyinc/savvy-cli/server"
+	"github.com/muesli/termenv"
+)
+
+type Exporter interface {
+	ToMarkdownFile(ctx context.Context)
+	ToSavvyArtifact(ctx context.Context, cl client.Client) error
+}
+
+func NewExporter(commands []*server.RecordedCommand) Exporter {
+	return &exporter{
+		commands: commands,
+	}
+}
+
+type exporter struct {
+	commands []*server.RecordedCommand
+}
+
+func (e *exporter) ToMarkdownFile(ctx context.Context) {
+	panic("implement me")
+}
+
+func (e *exporter) ToSavvyArtifact(ctx context.Context, cl client.Client) error {
+	gctx, cancel := context.WithCancel(ctx)
+	gm := component.NewGenerateRunbookModel(e.commands, cl)
+	var programOutput = termenv.NewOutput(os.Stdout, termenv.WithColorCache(true))
+	p := tea.NewProgram(gm, tea.WithOutput(programOutput), tea.WithContext(gctx))
+	if _, err := p.Run(); err != nil {
+		err = fmt.Errorf("failed to generate runbook: %w", err)
+		return err
+	}
+
+	// ensure the bubble tea program is finished before we start the next one
+	cancel()
+	p.Wait()
+
+	runbook := <-gm.RunbookCh()
+	m, err := newDisplayCommandsModel(runbook)
+	if err != nil {
+		return err
+	}
+
+	p = tea.NewProgram(m, tea.WithOutput(programOutput), tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		// TODO: fail gracefully and provide users a link to view the runbook
+		err = fmt.Errorf("could not display runbook: %w", err)
+		return err
+	}
+	if runbook.URL != "" {
+		display.Success("View and edit your runbook online at: " + runbook.URL)
+		return nil
+	}
+	return nil
+}
+
+type displayCommands struct {
+	l list.Model
+}
+
+func newDisplayCommandsModel(runbook *component.Runbook) (*displayCommands, error) {
+	if runbook == nil {
+		return nil, errors.New("runbook is empty")
+	}
+
+	listItems := toItems(runbook.Steps)
+	l := list.NewModel(listItems, runbook.Title, runbook.URL, list.EditOnlineBinding)
+	return &displayCommands{l: l}, nil
+}
+
+func (dc *displayCommands) Init() tea.Cmd {
+	// Just return `nil`, which means "no I/O right now, please."
+	dc.l.Init()
+	return nil
+}
+
+func (dc *displayCommands) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return dc.l.Update(msg)
+}
+
+func toItems(steps []component.RunbookStep) []list.Item {
+	var items []list.Item
+	for _, step := range steps {
+		items = append(items, list.Item{
+			Command:         step.Command,
+			DescriptionText: step.Description,
+		})
+	}
+	return items
+}
+
+func (dc *displayCommands) View() string {
+	return dc.l.View()
+}


### PR DESCRIPTION
- **export: Unify code to export a runbook to Savvy into its own pkg**
- **cmd/ask: reuse toListItems when displaying results of savvy ask**
- **export: Select export format**
- **export: impl md export**
- **export: write md to clipboard for easy sharing**
