### PR TITLE
Detect expired tokens and prompt login 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -89,7 +89,7 @@ func New() (Client, error) {
 	}
 
 	cl := &http.Client{
-		Transport: authz.NewRoundTripper(cfg.Token, config.Version()),
+		Transport: authz.NewRoundTripper(cfg.Token, config.Version(), ErrInvalidClient),
 	}
 
 	c := &client{


### PR DESCRIPTION
Fix a regressions I introduced in an earlier refactor.

The root cause was using ErrInvalidClient in both authz and client pkgs.

This change removes authz's Err to avoid a similar error in the future. 
